### PR TITLE
Add trajectory visualization and refine Fujix hook

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -694,6 +694,9 @@ MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_S
 
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, -1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unpredicted shadow tee (0 = off, 1 = on, -1 = don't even show in debug mode)")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
+MACRO_CONFIG_INT(ClFujixEnable, cl_fujix_enable, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable Fujix anti-freeze auto hook")
+MACRO_CONFIG_INT(ClFujixTicks, cl_fujix_ticks, 5, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to predict ahead for Fujix")
+MACRO_CONFIG_INT(ClShowFujixPrediction, cl_show_fujix_prediction, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show Fujix predicted trajectory")
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ninja skin")
 MACRO_CONFIG_INT(ClShowHookCollOther, cl_show_hook_coll_other, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision line (2 to always show)")
 MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own players' hook collision line (2 to always show)")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -11,6 +11,7 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/mapitems.h>
 
 #include <base/vmath.h>
 
@@ -18,10 +19,13 @@
 
 CControls::CControls()
 {
-	mem_zero(&m_aLastData, sizeof(m_aLastData));
-	mem_zero(m_aMousePos, sizeof(m_aMousePos));
-	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
-	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+        mem_zero(&m_aLastData, sizeof(m_aLastData));
+        mem_zero(m_aMousePos, sizeof(m_aMousePos));
+        mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
+        mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+
+       m_FujixTicksLeft = 0;
+       m_FujixTarget = vec2(0, 0);
 }
 
 void CControls::OnReset()
@@ -32,7 +36,9 @@ void CControls::OnReset()
 	for(int &AmmoCount : m_aAmmoCount)
 		AmmoCount = 0;
 
-	m_LastSendTime = 0;
+       m_LastSendTime = 0;
+
+       m_FujixTicksLeft = 0;
 }
 
 void CControls::ResetInput(int Dummy)
@@ -45,8 +51,10 @@ void CControls::ResetInput(int Dummy)
 	m_aLastData[Dummy].m_Jump = 0;
 	m_aInputData[Dummy] = m_aLastData[Dummy];
 
-	m_aInputDirectionLeft[Dummy] = 0;
-	m_aInputDirectionRight[Dummy] = 0;
+       m_aInputDirectionLeft[Dummy] = 0;
+       m_aInputDirectionRight[Dummy] = 0;
+
+       m_FujixTicksLeft = 0;
 }
 
 void CControls::OnPlayerDeath()
@@ -237,10 +245,117 @@ int CControls::SnapInput(int *pData)
 
 		// set direction
 		m_aInputData[g_Config.m_ClDummy].m_Direction = 0;
-		if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
-			m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
-		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
-			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
+               if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
+                       m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
+               if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
+                       m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
+
+               if(g_Config.m_ClFujixEnable && m_pClient->m_Snap.m_pLocalCharacter && !m_pClient->m_Snap.m_SpecInfo.m_Active)
+               {
+                       if(m_FujixTicksLeft == 0)
+                       {
+                               bool Freeze = false;
+                               CCharacterCore Pred = m_pClient->m_PredictedChar;
+                               Pred.m_Input = m_aInputData[g_Config.m_ClDummy];
+                               Pred.m_Input.m_Hook = 0;
+                               for(int i = 0; i < g_Config.m_ClFujixTicks; i++)
+                               {
+                                       Pred.Tick(true);
+                                       Pred.Move();
+                                       Pred.Quantize();
+                                       int MapIndex = Collision()->GetPureMapIndex(Pred.m_Pos);
+                                       int Tiles[3] = {Collision()->GetTileIndex(MapIndex), Collision()->GetFrontTileIndex(MapIndex), Collision()->GetSwitchType(MapIndex)};
+                                       for(int t : Tiles)
+                                       {
+                                               if(t == TILE_FREEZE || t == TILE_DFREEZE || t == TILE_LFREEZE || t == TILE_DEATH)
+                                               {
+                                                       Freeze = true;
+                                                       break;
+                                               }
+                                       }
+                                       if(Freeze)
+                                               break;
+                               }
+
+                               if(Freeze)
+                               {
+                                       static const vec2 Directions[] = {vec2(0, 1), vec2(-1, 1), vec2(1, 1), vec2(-1, 0), vec2(1, 0), vec2(-1, -1), vec2(1, -1), vec2(0, -1)};
+                                       float HookLen = m_pClient->m_aTuning[g_Config.m_ClDummy].m_HookLength;
+                                       for(const vec2 &Dir : Directions)
+                                       {
+                                               vec2 To = Pred.m_Pos + normalize(Dir) * HookLen;
+
+                                               bool ThroughFreeze = false;
+                                               for(int s = 0; s < 10 && !ThroughFreeze; s++)
+                                               {
+                                                       float a = (s + 1) / 10.0f;
+                                                       vec2 Pos = mix(Pred.m_Pos, To, a);
+                                                       int MapIdx = Collision()->GetPureMapIndex(Pos);
+                                                       int T[3] = {Collision()->GetTileIndex(MapIdx), Collision()->GetFrontTileIndex(MapIdx), Collision()->GetSwitchType(MapIdx)};
+                                                       for(int t : T)
+                                                       {
+                                                               if(t == TILE_FREEZE || t == TILE_DFREEZE || t == TILE_LFREEZE || t == TILE_DEATH)
+                                                               {
+                                                                       ThroughFreeze = true;
+                                                                       break;
+                                                               }
+                                                       }
+                                               }
+                                               if(ThroughFreeze)
+                                                       continue;
+
+                                               vec2 Col, Before;
+                                               int Hit = Collision()->IntersectLine(Pred.m_Pos, To, &Col, &Before);
+                                               if(!Hit)
+                                                       continue;
+                                               if(Hit == TILE_NOHOOK || Hit == TILE_FREEZE || Hit == TILE_DFREEZE || Hit == TILE_LFREEZE || Hit == TILE_DEATH)
+                                                       continue;
+
+                                               CCharacterCore HookPred = Pred;
+                                               HookPred.m_Input = m_aInputData[g_Config.m_ClDummy];
+                                               HookPred.m_Input.m_Hook = 1;
+                                               HookPred.m_Input.m_TargetX = (int)(Dir.x * 256);
+                                               HookPred.m_Input.m_TargetY = (int)(Dir.y * 256);
+                                               bool Safe = true;
+                                               for(int s = 0; s < g_Config.m_ClFujixTicks && Safe; s++)
+                                               {
+                                                       HookPred.Tick(true);
+                                                       HookPred.Move();
+                                                       HookPred.Quantize();
+                                                       int MapIndex2 = Collision()->GetPureMapIndex(HookPred.m_Pos);
+                                                       int Tiles2[3] = {Collision()->GetTileIndex(MapIndex2), Collision()->GetFrontTileIndex(MapIndex2), Collision()->GetSwitchType(MapIndex2)};
+                                                       for(int t : Tiles2)
+                                                       {
+                                                               if(t == TILE_FREEZE || t == TILE_DFREEZE || t == TILE_LFREEZE || t == TILE_DEATH)
+                                                               {
+                                                                       Safe = false;
+                                                                       break;
+                                                               }
+                                                       }
+                                                       if(HookPred.m_HookState == HOOK_RETRACT_START || HookPred.m_HookState == HOOK_RETRACTED)
+                                                               Safe = false;
+                                               }
+
+                                               if(Safe)
+                                               {
+                                                       m_FujixTicksLeft = 10;
+                                                       m_FujixTarget = Col;
+                                                       break;
+                                               }
+                                       }
+                               }
+                       }
+               }
+
+               if(m_FujixTicksLeft > 0)
+               {
+                       vec2 LocalPos = m_pClient->m_LocalCharacterPos;
+                       vec2 Dir = normalize(m_FujixTarget - LocalPos);
+                       m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)(Dir.x * GetMaxMouseDistance());
+                       m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)(Dir.y * GetMaxMouseDistance());
+                       m_aInputData[g_Config.m_ClDummy].m_Hook = 1;
+                       m_FujixTicksLeft--;
+               }
 
 		// dummy copy moves
 		if(g_Config.m_ClDummyCopyMoves)
@@ -355,10 +470,36 @@ void CControls::OnRender()
 	{
 		m_aTargetPos[g_Config.m_ClDummy] = m_pClient->m_Snap.m_SpecInfo.m_Position + m_aMousePos[g_Config.m_ClDummy];
 	}
-	else
-	{
-		m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
-	}
+       else
+       {
+               m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
+       }
+
+       if(g_Config.m_ClFujixEnable && g_Config.m_ClShowFujixPrediction && m_pClient->m_Snap.m_pLocalCharacter && !m_pClient->m_Snap.m_SpecInfo.m_Active)
+       {
+               CCharacterCore Pred = m_pClient->m_PredictedChar;
+               Pred.m_Input = m_aInputData[g_Config.m_ClDummy];
+               Pred.m_Input.m_Hook = 0;
+               vec2 OldPos = Pred.m_Pos;
+               IGraphics::CLineItem aLines[64];
+               int Num = 0;
+               for(int i = 0; i < g_Config.m_ClFujixTicks; i++)
+               {
+                       Pred.Tick(true);
+                       Pred.Move();
+                       Pred.Quantize();
+                       aLines[Num++] = IGraphics::CLineItem(OldPos.x, OldPos.y, Pred.m_Pos.x, Pred.m_Pos.y);
+                       OldPos = Pred.m_Pos;
+               }
+               if(Num > 0)
+               {
+                       Graphics()->TextureClear();
+                       Graphics()->LinesBegin();
+                       Graphics()->SetColor(1.0f, 0.6f, 0.0f, 0.75f);
+                       Graphics()->LinesDraw(aLines, Num);
+                       Graphics()->LinesEnd();
+               }
+       }
 }
 
 bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -26,8 +26,11 @@ public:
 	CNetObj_PlayerInput m_aInputData[NUM_DUMMIES];
 	CNetObj_PlayerInput m_aLastData[NUM_DUMMIES];
 	int m_aInputDirectionLeft[NUM_DUMMIES];
-	int m_aInputDirectionRight[NUM_DUMMIES];
-	int m_aShowHookColl[NUM_DUMMIES];
+       int m_aInputDirectionRight[NUM_DUMMIES];
+       int m_aShowHookColl[NUM_DUMMIES];
+
+       int m_FujixTicksLeft;
+       vec2 m_FujixTarget;
 
 	CControls();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -616,10 +616,11 @@ protected:
 	void RenderSettingsTeeCustom7(CUIRect MainView);
 	void RenderSkinSelection7(CUIRect MainView);
 	void RenderSkinPartSelection7(CUIRect MainView);
-	void RenderSettingsControls(CUIRect MainView);
-	void ResetSettingsControls();
-	void RenderSettingsGraphics(CUIRect MainView);
-	void RenderSettingsSound(CUIRect MainView);
+       void RenderSettingsControls(CUIRect MainView);
+       void ResetSettingsControls();
+       void RenderSettingsGraphics(CUIRect MainView);
+       void RenderSettingsFujix(CUIRect MainView);
+       void RenderSettingsSound(CUIRect MainView);
 	void RenderSettings(CUIRect MainView);
 	void RenderSettingsCustom(CUIRect MainView);
 
@@ -722,8 +723,9 @@ public:
 		SETTINGS_TEE,
 		SETTINGS_APPEARANCE,
 		SETTINGS_CONTROLS,
-		SETTINGS_GRAPHICS,
-		SETTINGS_SOUND,
+               SETTINGS_GRAPHICS,
+               SETTINGS_FUJIX,
+               SETTINGS_SOUND,
 		SETTINGS_DDNET,
 		SETTINGS_ASSETS,
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1745,12 +1745,29 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	}
 
 	// check if the new settings require a restart
-	if(CheckSettings)
-	{
-		m_NeedRestartGraphics = !(s_GfxFsaaSamples == g_Config.m_GfxFsaaSamples &&
-					  !s_GfxBackendChanged &&
-					  !s_GfxGpuChanged);
-	}
+        if(CheckSettings)
+        {
+                m_NeedRestartGraphics = !(s_GfxFsaaSamples == g_Config.m_GfxFsaaSamples &&
+                                          !s_GfxBackendChanged &&
+                                          !s_GfxGpuChanged);
+        }
+}
+
+void CMenus::RenderSettingsFujix(CUIRect MainView)
+{
+       CUIRect Button;
+       MainView.HSplitTop(20.0f, &Button, &MainView);
+       if(DoButton_CheckBox(&g_Config.m_ClFujixEnable, "Enable Fujix", g_Config.m_ClFujixEnable, &Button))
+               g_Config.m_ClFujixEnable ^= 1;
+
+       MainView.HSplitTop(20.0f, &Button, &MainView);
+       if(DoButton_CheckBox(&g_Config.m_ClShowFujixPrediction, "Show prediction", g_Config.m_ClShowFujixPrediction, &Button))
+               g_Config.m_ClShowFujixPrediction ^= 1;
+
+       MainView.HSplitTop(20.0f, &Button, &MainView);
+       char aBuf[64];
+       str_format(aBuf, sizeof(aBuf), "Prediction Ticks: %d", g_Config.m_ClFujixTicks);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTicks, &g_Config.m_ClFujixTicks, &Button, aBuf, 1, 20);
 }
 
 void CMenus::RenderSettingsSound(CUIRect MainView)
@@ -1959,9 +1976,10 @@ void CMenus::RenderSettings(CUIRect MainView)
 		Localize("Player"),
 		Client()->IsSixup() ? "Tee 0.7" : Localize("Tee"),
 		Localize("Appearance"),
-		Localize("Controls"),
-		Localize("Graphics"),
-		Localize("Sound"),
+               Localize("Controls"),
+               Localize("Graphics"),
+               "FUJIX",
+               Localize("Sound"),
 		Localize("DDNet"),
 		Localize("Assets")};
 	static CButtonContainer s_aTabButtons[SETTINGS_LENGTH];
@@ -2007,12 +2025,17 @@ void CMenus::RenderSettings(CUIRect MainView)
 		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_CONTROLS);
 		RenderSettingsControls(MainView);
 	}
-	else if(g_Config.m_UiSettingsPage == SETTINGS_GRAPHICS)
-	{
-		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_GRAPHICS);
-		RenderSettingsGraphics(MainView);
-	}
-	else if(g_Config.m_UiSettingsPage == SETTINGS_SOUND)
+       else if(g_Config.m_UiSettingsPage == SETTINGS_GRAPHICS)
+       {
+               GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_GRAPHICS);
+               RenderSettingsGraphics(MainView);
+       }
+       else if(g_Config.m_UiSettingsPage == SETTINGS_FUJIX)
+       {
+               GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_RESERVED0);
+               RenderSettingsFujix(MainView);
+       }
+       else if(g_Config.m_UiSettingsPage == SETTINGS_SOUND)
 	{
 		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_SOUND);
 		RenderSettingsSound(MainView);


### PR DESCRIPTION
## Summary
- add option to show Fujix prediction path
- improve hook targeting to avoid freeze tiles
- display predicted trajectory if enabled

## Testing
- `python3 scripts/check_config_variables.py`
- `./scripts/check_standard_headers.sh`
- `python3 scripts/check_unused_header_files.py`


------
https://chatgpt.com/codex/tasks/task_e_683f6b317dbc832cba907f4ae4445f4d