### PR TITLE
Improve Fujix prediction

### DIFF
--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -32,6 +32,8 @@ public:
        int m_FujixTicksLeft;
        vec2 m_FujixTarget;
        int m_FujixLockControls;
+       int m_FujixFallbackTicksLeft;
+       bool m_FujixUsingFallback;
 
        bool IsKoGMap() const;
 

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -33,6 +33,8 @@ public:
        vec2 m_FujixTarget;
        int m_FujixLockControls;
 
+       bool IsKoGMap() const;
+
 	CControls();
 	virtual int Sizeof() const override { return sizeof(*this); }
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1978,7 +1978,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 		Localize("Appearance"),
                Localize("Controls"),
                Localize("Graphics"),
-               "AUTOHOOK",
+               "FUJIX",
                Localize("Sound"),
 		Localize("DDNet"),
 		Localize("Assets")};


### PR DESCRIPTION
## Summary
- rename `AUTOHOOK` settings tab to `FUJIX`
- enhance Fujix auto-hook with KoG map detection and player hooking
- draw Fujix prediction line and ghost tee

## Testing
- `python3 scripts/fix_style.py src/game/client/components/controls.cpp src/game/client/components/controls.h src/game/client/components/menus_settings.cpp` *(fails: Found no clang-format 10)*

------
https://chatgpt.com/codex/tasks/task_e_68404749c15c832caf1b380bb86949c5