### PR TITLE
Improve Fujix hook safety

### DIFF
--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -32,6 +32,8 @@ public:
        int m_FujixTicksLeft;
        vec2 m_FujixTarget;
        int m_FujixLockControls;
+       int m_FujixFallbackTicksLeft;
+       bool m_FujixUsingFallback;
 
 	CControls();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1978,7 +1978,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 		Localize("Appearance"),
                Localize("Controls"),
                Localize("Graphics"),
-               "AUTOHOOK",
+               "FUJIX",
                Localize("Sound"),
 		Localize("DDNet"),
 		Localize("Assets")};


### PR DESCRIPTION
## Summary
- keep 64 direction search everywhere
- extend post-release safety simulation
- lengthen fallback hook timer
- remove unused KoG map helper

## Testing
- `python3 scripts/fix_style.py src/game/client/components/controls.cpp src/game/client/components/controls.h src/game/client/components/menus_settings.cpp` *(fails: Found no clang-format 10)*

------
https://chatgpt.com/codex/tasks/task_e_68404749c15c832caf1b380bb86949c5