### PR TITLE
Fix Fujix predicted tee drawing

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -609,7 +609,8 @@ void CControls::OnRender()
                m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
        }
 
-       DrawFujixPrediction();
+UpdateFujixPrediction();
+DrawFujixPrediction();
 }
 
 void CControls::DrawFujixPrediction()


### PR DESCRIPTION
## Summary
- ensure Fujix prediction is updated before drawing

## Testing
- `scripts/fix_style.py` *(fails: Found no clang-format 10)*
- `cmake -Bbuild -GNinja` *(fails: glslangValidator binary was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2e60bfc832c8000ad4338b96e31