### PR TITLE
Fix Fujix predicted tee update

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -609,7 +609,8 @@ void CControls::OnRender()
                m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
        }
 
-       DrawFujixPrediction();
+UpdateFujixPrediction();
+DrawFujixPrediction();
 }
 
 void CControls::DrawFujixPrediction()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3414,8 +3414,11 @@ void CGameClient::UpdateSpectatorCursor()
 	}
 
 	// if we are in auto spec mode, use camera zoom to smooth out cursor transitions
-	const float Zoom = (m_Camera.m_Zooming && m_Camera.m_AutoSpecCameraZooming) ? m_Camera.m_Zoom : m_Snap.m_SpecInfo.m_Zoom;
-	m_CursorInfo.m_WorldTarget = m_CursorInfo.m_Position + (m_CursorInfo.m_Target - TargetCameraOffset) * Zoom + TargetCameraOffset;
+       const float Zoom = (m_Camera.m_Zooming && m_Camera.m_AutoSpecCameraZooming) ? m_Camera.m_Zoom : m_Snap.m_SpecInfo.m_Zoom;
+       m_CursorInfo.m_WorldTarget = m_CursorInfo.m_Position + (m_CursorInfo.m_Target - TargetCameraOffset) * Zoom + TargetCameraOffset;
+
+       // update Fujix prediction after we have new prediction data for this tick
+       m_Controls.UpdateFujixPrediction();
 }
 
 void CGameClient::UpdateRenderedCharacters()


### PR DESCRIPTION
## Summary
- refresh Fujix prediction whenever the world prediction updates

## Testing
- `scripts/fix_style.py` *(fails: Found no clang-format 10)*
- `cmake -Bbuild -GNinja` *(fails: glslangValidator binary was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2e60bfc832c8000ad4338b96e31