### PR TITLE
Add FUJIX safe freeze option

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -768,3 +768,5 @@ MACRO_CONFIG_INT(ClVideoRecorderFPS, cl_video_recorder_fps, 60, 1, 1000, CFGFLAG
 /*
  * Add config variables for mods below this comment to avoid merge conflicts.
  */
+MACRO_CONFIG_INT(ClFujixSafeFreeze, cl_fujix_safefreeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable safe freeze")
+MACRO_CONFIG_INT(ClFujixSafeFreezeTicks, cl_fujix_safefreeze_ticks, 5, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction ticks for safe freeze")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -11,6 +11,7 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/mapitems.h>
 
 #include <base/vmath.h>
 
@@ -357,8 +358,24 @@ void CControls::OnRender()
 	}
 	else
 	{
-		m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
-	}
+               m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
+       }
+
+       if(g_Config.m_ClFujixSafeFreeze && m_pClient->m_Snap.m_pLocalCharacter)
+       {
+               vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+               for(int i = 1; i <= g_Config.m_ClFujixSafeFreezeTicks; i++)
+               {
+                       vec2 CheckPos = Pos + vec2(0.0f, i * 32.0f);
+                       int Tile = Collision()->GetTileIndex(Collision()->GetPureMapIndex(CheckPos));
+                       if(Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE)
+                       {
+                               m_aInputData[g_Config.m_ClDummy].m_Hook = 1;
+                               m_aTargetPos[g_Config.m_ClDummy] = vec2(0.0f, -100.0f);
+                               break;
+                       }
+               }
+       }
 }
 
 bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -30,9 +30,10 @@ enum
 	ASSETS_TAB_GAME = 1,
 	ASSETS_TAB_EMOTICONS = 2,
 	ASSETS_TAB_PARTICLES = 3,
-	ASSETS_TAB_HUD = 4,
-	ASSETS_TAB_EXTRAS = 5,
-	NUMBER_OF_ASSETS_TABS = 6,
+       ASSETS_TAB_HUD = 4,
+       ASSETS_TAB_EXTRAS = 5,
+       ASSETS_TAB_FUJIX = 6,
+       NUMBER_OF_ASSETS_TABS = 7,
 };
 
 void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
@@ -353,13 +354,14 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	const float TabWidth = TabBar.w / NUMBER_OF_ASSETS_TABS;
 	static CButtonContainer s_aPageTabs[NUMBER_OF_ASSETS_TABS] = {};
-	const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
-		Localize("Entities"),
-		Localize("Game"),
-		Localize("Emoticons"),
-		Localize("Particles"),
-		Localize("HUD"),
-		Localize("Extras")};
+       const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
+               Localize("Entities"),
+               Localize("Game"),
+               Localize("Emoticons"),
+               Localize("Particles"),
+               Localize("HUD"),
+               Localize("Extras"),
+               "FUJIX"};
 
 	for(int Tab = ASSETS_TAB_ENTITIES; Tab < NUMBER_OF_ASSETS_TABS; ++Tab)
 	{
@@ -416,10 +418,21 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		InitAssetList(m_vExtrasList, "assets/extras", "extras", ExtrasScan, Graphics(), Storage(), &User);
 	}
 
-	MainView.HSplitTop(10.0f, nullptr, &MainView);
+       MainView.HSplitTop(10.0f, nullptr, &MainView);
 
-	// skin selector
-	MainView.HSplitTop(MainView.h - 10.0f - ms_ButtonHeight, &CustomList, &MainView);
+       if(s_CurCustomTab == ASSETS_TAB_FUJIX)
+       {
+               CUIRect Row;
+               MainView.HSplitTop(20.0f, &Row, &MainView);
+               if(DoButton_CheckBox(&g_Config.m_ClFujixSafeFreeze, "Safe freeze", g_Config.m_ClFujixSafeFreeze, &Row))
+                       g_Config.m_ClFujixSafeFreeze ^= 1;
+               MainView.HSplitTop(20.0f, &Row, &MainView);
+               Ui()->DoScrollbarOption(&g_Config.m_ClFujixSafeFreezeTicks, &g_Config.m_ClFujixSafeFreezeTicks, &Row, "Ticks", 1, 20, &CUi::ms_LinearScrollbarScale);
+               return;
+       }
+
+       // skin selector
+       MainView.HSplitTop(MainView.h - 10.0f - ms_ButtonHeight, &CustomList, &MainView);
 	if(gs_aInitCustomList[s_CurCustomTab])
 	{
 		int ListSize = 0;


### PR DESCRIPTION
## Summary
- introduce new config variables `cl_fujix_safefreeze` and `cl_fujix_safefreeze_ticks`
- extend Assets settings with a new FUJIX tab
- add simple safe freeze prediction logic in controls to hook upwards

## Testing
- `scripts/fix_style.py --dry-run` *(fails: Found no clang-format 10)*
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6841acacafa4832cbe10d9c62b0e9271