### PR TITLE
Adjust safe freeze hook behavior

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -770,3 +770,4 @@ MACRO_CONFIG_INT(ClVideoRecorderFPS, cl_video_recorder_fps, 60, 1, 1000, CFGFLAG
  */
 MACRO_CONFIG_INT(ClFujixSafeFreeze, cl_fujix_safefreeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable safe freeze")
 MACRO_CONFIG_INT(ClFujixSafeFreezeTicks, cl_fujix_safefreeze_ticks, 5, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction ticks for safe freeze")
+MACRO_CONFIG_INT(ClFujixSafeFreezeTrigger, cl_fujix_safefreeze_trigger, 2, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Distance in tiles to freeze to trigger safe freeze")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -370,21 +370,22 @@ void CControls::OnRender()
                vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
                vec2 Vel = GameClient()->m_PredictedChar.m_Vel;
 
-               bool FallingIntoFreeze = Vel.y > 0.0f;
-               if(FallingIntoFreeze)
+               int FreezeDist = -1;
+               if(Vel.y > 0.0f)
                {
-                       FallingIntoFreeze = false;
                        for(int i = 1; i <= g_Config.m_ClFujixSafeFreezeTicks; i++)
                        {
                                vec2 CheckPos = Pos + vec2(0.0f, i * 32.0f);
                                int Tile = Collision()->GetTileIndex(Collision()->GetPureMapIndex(CheckPos));
                                if(Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE)
                                {
-                                       FallingIntoFreeze = true;
+                                       FreezeDist = i;
                                        break;
                                }
                        }
                }
+
+               bool FallingIntoFreeze = FreezeDist > 0 && FreezeDist <= g_Config.m_ClFujixSafeFreezeTrigger;
 
                if(FallingIntoFreeze && !m_SafeFreezeActive)
                        m_SafeFreezeActive = true;
@@ -402,7 +403,7 @@ void CControls::OnRender()
                                        int Tile = Collision()->GetTileIndex(Collision()->GetPureMapIndex(Candidate));
                                        if(Tile != TILE_FREEZE && Tile != TILE_DFREEZE && Tile != TILE_LFREEZE && Tile != TILE_NOHOOK)
                                        {
-                                               HookTarget = Candidate;
+                                               HookTarget = Candidate + vec2(0.0f, 16.0f);
                                                y = g_Config.m_ClFujixSafeFreezeTicks * 2 + 1;
                                                break;
                                        }

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -428,6 +428,8 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
                        g_Config.m_ClFujixSafeFreeze ^= 1;
                MainView.HSplitTop(20.0f, &Row, &MainView);
                Ui()->DoScrollbarOption(&g_Config.m_ClFujixSafeFreezeTicks, &g_Config.m_ClFujixSafeFreezeTicks, &Row, "Ticks", 1, 20, &CUi::ms_LinearScrollbarScale);
+               MainView.HSplitTop(20.0f, &Row, &MainView);
+               Ui()->DoScrollbarOption(&g_Config.m_ClFujixSafeFreezeTrigger, &g_Config.m_ClFujixSafeFreezeTrigger, &Row, "Trigger", 1, 20, &CUi::ms_LinearScrollbarScale);
                return;
        }
 


### PR DESCRIPTION
## Summary
- add a trigger distance option for safe freeze
- delay auto hook until close to freeze zone
- offset hook target to reduce freeze ceiling hits

## Testing
- `python3 scripts/fix_style.py --dry-run` *(fails: Found no clang-format 10)*
- `cmake ..` *(fails: glslangValidator binary was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d50f4e30832c806186aaa865938a