### PR TITLE
Fix missing includes for Fujix recorder

### DIFF
--- a/src/game/client/components/fujix_recorder.h
+++ b/src/game/client/components/fujix_recorder.h
@@ -4,6 +4,8 @@
 #include <game/client/component.h>
 #include <engine/console.h>
 #include <engine/demo.h>
+#include <engine/shared/demo.h>
+#include <engine/shared/snapshot.h>
 #include <engine/shared/protocol.h>
 #include <game/generated/protocol.h>
 #include <vector>


### PR DESCRIPTION
## Summary
- include CDemoPlayer and CSnapshotDelta headers in `fujix_recorder.h`

## Testing
- `cmake -Bbuild -GNinja` *(fails: Ogg, Opus, Opusfile, SDL2, Vulkan not found)*

------
https://chatgpt.com/codex/tasks/task_e_684354ca291c832cbff8ab31b95f7330