### PR TITLE
Implement simple FUJIX TAS recorder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2382,6 +2382,8 @@ if(CLIENT)
     components/players.h
     components/race_demo.cpp
     components/race_demo.h
+    components/fujix_tas.cpp
+    components/fujix_tas.h
     components/scoreboard.cpp
     components/scoreboard.h
     components/skins.cpp

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -647,6 +647,8 @@ MACRO_CONFIG_STR(ClMenuMap, cl_menu_map, 100, "auto", CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClRotationRadius, cl_rotation_radius, 30, 1, 500, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera rotation radius")
 MACRO_CONFIG_INT(ClRotationSpeed, cl_rotation_speed, 40, 1, 120, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera rotations in seconds")
 MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 40, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera speed")
+MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Record FUJIX TAS")
+MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -1,0 +1,144 @@
+#include "fujix_tas.h"
+
+#include <engine/shared/config.h>
+#include <engine/storage.h>
+#include <engine/console.h>
+#include <engine/client.h>
+#include <game/client/gameclient.h>
+
+const char *CFujixTas::ms_pFujixDir = "fujix";
+
+CFujixTas::CFujixTas()
+{
+    m_Recording = false;
+    m_Playing = false;
+    m_File = nullptr;
+    m_PlayIndex = 0;
+    m_aFilename[0] = '\0';
+}
+
+void CFujixTas::GetPath(char *pBuf, int Size) const
+{
+    const char *pMap = Client()->GetCurrentMap();
+    str_format(pBuf, Size, "%s/%s.fjx", ms_pFujixDir, pMap);
+}
+
+void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
+{
+    if(!m_Recording || !m_File)
+        return;
+    SEntry e{Tick, *pInput};
+    io_write(m_File, &e, sizeof(e));
+}
+
+bool CFujixTas::FetchEntry(CNetObj_PlayerInput *pInput)
+{
+    if(!m_Playing || m_PlayIndex >= (int)m_vEntries.size())
+        return false;
+    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    if(m_vEntries[m_PlayIndex].m_Tick > PredTick)
+        return false;
+
+    *pInput = m_vEntries[m_PlayIndex].m_Input;
+    m_PlayIndex++;
+    if(m_PlayIndex >= (int)m_vEntries.size())
+        m_Playing = false;
+    return true;
+}
+
+void CFujixTas::StartRecord()
+{
+    if(m_Recording)
+        return;
+    GetPath(m_aFilename, sizeof(m_aFilename));
+    Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
+    m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    if(!m_File)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for recording");
+        return;
+    }
+    m_Recording = true;
+}
+
+void CFujixTas::StopRecord()
+{
+    if(!m_Recording)
+        return;
+    if(m_File)
+        io_close(m_File);
+    m_File = nullptr;
+    m_Recording = false;
+}
+
+void CFujixTas::StartPlay()
+{
+    if(m_Playing)
+        StopPlay();
+
+    char aPath[IO_MAX_PATH_LENGTH];
+    GetPath(aPath, sizeof(aPath));
+    IOHANDLE File = Storage()->OpenFile(aPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    if(!File)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for playback");
+        return;
+    }
+
+    m_vEntries.clear();
+    SEntry e;
+    while(io_read(File, &e, sizeof(e)) == sizeof(e))
+        m_vEntries.push_back(e);
+    io_close(File);
+
+    m_PlayIndex = 0;
+    m_Playing = !m_vEntries.empty();
+}
+
+void CFujixTas::StopPlay()
+{
+    m_Playing = false;
+    m_vEntries.clear();
+    m_PlayIndex = 0;
+}
+
+bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
+{
+    return FetchEntry(pInput);
+}
+
+void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
+{
+    RecordEntry(pInput, Tick);
+}
+
+void CFujixTas::ConRecord(IConsole::IResult *pResult, void *pUserData)
+{
+    CFujixTas *pSelf = static_cast<CFujixTas *>(pUserData);
+    if(pSelf->m_Recording)
+        pSelf->StopRecord();
+    else
+        pSelf->StartRecord();
+}
+
+void CFujixTas::ConPlay(IConsole::IResult *pResult, void *pUserData)
+{
+    CFujixTas *pSelf = static_cast<CFujixTas *>(pUserData);
+    if(pSelf->m_Playing)
+        pSelf->StopPlay();
+    else
+        pSelf->StartPlay();
+}
+
+void CFujixTas::OnConsoleInit()
+{
+    Console()->Register("fujix_record", "", CFGFLAG_CLIENT, ConRecord, this, "Start/stop FUJIX TAS recording");
+    Console()->Register("fujix_play", "", CFGFLAG_CLIENT, ConPlay, this, "Play FUJIX TAS for current map");
+}
+
+void CFujixTas::OnMapLoad()
+{
+    Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
+}
+
+*** End File

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -1,0 +1,50 @@
+#ifndef GAME_CLIENT_COMPONENTS_FUJIX_TAS_H
+#define GAME_CLIENT_COMPONENTS_FUJIX_TAS_H
+
+#include <game/client/component.h>
+#include <vector>
+
+class CFujixTas : public CComponent
+{
+public:
+    static const char *ms_pFujixDir;
+
+private:
+    struct SEntry
+    {
+        int m_Tick;
+        CNetObj_PlayerInput m_Input;
+    };
+
+    bool m_Recording;
+    bool m_Playing;
+    char m_aFilename[IO_MAX_PATH_LENGTH];
+    IOHANDLE m_File;
+    std::vector<SEntry> m_vEntries;
+    int m_PlayIndex;
+
+    void GetPath(char *pBuf, int Size) const;
+    void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
+    bool FetchEntry(CNetObj_PlayerInput *pInput);
+
+    static void ConRecord(IConsole::IResult *pResult, void *pUserData);
+    static void ConPlay(IConsole::IResult *pResult, void *pUserData);
+
+public:
+    CFujixTas();
+    virtual int Sizeof() const override { return sizeof(*this); }
+
+    virtual void OnConsoleInit() override;
+    virtual void OnMapLoad() override;
+
+    void StartRecord();
+    void StopRecord();
+    void StartPlay();
+    void StopPlay();
+    bool IsRecording() const { return m_Recording; }
+    bool IsPlaying() const { return m_Playing; }
+    bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
+    void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
+};
+
+#endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -29,10 +29,11 @@ enum
 	ASSETS_TAB_ENTITIES = 0,
 	ASSETS_TAB_GAME = 1,
 	ASSETS_TAB_EMOTICONS = 2,
-	ASSETS_TAB_PARTICLES = 3,
-	ASSETS_TAB_HUD = 4,
-	ASSETS_TAB_EXTRAS = 5,
-	NUMBER_OF_ASSETS_TABS = 6,
+        ASSETS_TAB_PARTICLES = 3,
+        ASSETS_TAB_HUD = 4,
+        ASSETS_TAB_EXTRAS = 5,
+        ASSETS_TAB_FUJIX = 6,
+        NUMBER_OF_ASSETS_TABS = 7,
 };
 
 void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
@@ -217,11 +218,11 @@ static std::vector<const CMenus::SCustomHud *> gs_vpSearchHudList;
 static std::vector<const CMenus::SCustomExtras *> gs_vpSearchExtrasList;
 
 static bool gs_aInitCustomList[NUMBER_OF_ASSETS_TABS] = {
-	true,
+       true, false, false, false, false, false, false,
 };
 
 static size_t gs_aCustomListSize[NUMBER_OF_ASSETS_TABS] = {
-	0,
+       0, 0, 0, 0, 0, 0, 0,
 };
 
 static CLineInputBuffered<64> s_aFilterInputs[NUMBER_OF_ASSETS_TABS];
@@ -238,12 +239,14 @@ static const CMenus::SCustomItem *GetCustomItem(int CurTab, size_t Index)
 		return gs_vpSearchEmoticonsList[Index];
 	else if(CurTab == ASSETS_TAB_PARTICLES)
 		return gs_vpSearchParticlesList[Index];
-	else if(CurTab == ASSETS_TAB_HUD)
-		return gs_vpSearchHudList[Index];
-	else if(CurTab == ASSETS_TAB_EXTRAS)
-		return gs_vpSearchExtrasList[Index];
+        else if(CurTab == ASSETS_TAB_HUD)
+                return gs_vpSearchHudList[Index];
+        else if(CurTab == ASSETS_TAB_EXTRAS)
+                return gs_vpSearchExtrasList[Index];
+        else if(CurTab == ASSETS_TAB_FUJIX)
+                return nullptr;
 
-	return nullptr;
+        return nullptr;
 }
 
 template<typename TName>
@@ -356,10 +359,11 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
 		Localize("Entities"),
 		Localize("Game"),
-		Localize("Emoticons"),
-		Localize("Particles"),
-		Localize("HUD"),
-		Localize("Extras")};
+               Localize("Emoticons"),
+               Localize("Particles"),
+               Localize("HUD"),
+               Localize("Extras"),
+               "FUJIX"};
 
 	for(int Tab = ASSETS_TAB_ENTITIES; Tab < NUMBER_OF_ASSETS_TABS; ++Tab)
 	{
@@ -411,10 +415,14 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	{
 		InitAssetList(m_vHudList, "assets/hud", "hud", HudScan, Graphics(), Storage(), &User);
 	}
-	else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
-	{
-		InitAssetList(m_vExtrasList, "assets/extras", "extras", ExtrasScan, Graphics(), Storage(), &User);
-	}
+        else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
+        {
+                InitAssetList(m_vExtrasList, "assets/extras", "extras", ExtrasScan, Graphics(), Storage(), &User);
+        }
+        else if(s_CurCustomTab == ASSETS_TAB_FUJIX)
+        {
+                // no assets to load
+        }
 
 	MainView.HSplitTop(10.0f, nullptr, &MainView);
 
@@ -454,11 +462,15 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		{
 			ListSize = InitSearchList(gs_vpSearchHudList, m_vHudList);
 		}
-		else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
-		{
-			ListSize = InitSearchList(gs_vpSearchExtrasList, m_vExtrasList);
-		}
-		gs_aInitCustomList[s_CurCustomTab] = false;
+               else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
+               {
+                       ListSize = InitSearchList(gs_vpSearchExtrasList, m_vExtrasList);
+               }
+               else if(s_CurCustomTab == ASSETS_TAB_FUJIX)
+               {
+                        ListSize = 0;
+               }
+               gs_aInitCustomList[s_CurCustomTab] = false;
 		gs_aCustomListSize[s_CurCustomTab] = ListSize;
 	}
 
@@ -490,15 +502,20 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	{
 		SearchListSize = gs_vpSearchHudList.size();
 	}
-	else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
-	{
-		SearchListSize = gs_vpSearchExtrasList.size();
-	}
+       else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
+       {
+               SearchListSize = gs_vpSearchExtrasList.size();
+       }
+       else if(s_CurCustomTab == ASSETS_TAB_FUJIX)
+       {
+               SearchListSize = 0;
+       }
 
-	static CListBox s_ListBox;
-	s_ListBox.DoStart(TextureHeight + 15.0f + 10.0f + Margin, SearchListSize, CustomList.w / (Margin + TextureWidth), 1, OldSelected, &CustomList, false);
-	for(size_t i = 0; i < SearchListSize; ++i)
-	{
+       static CListBox s_ListBox;
+       if(s_CurCustomTab != ASSETS_TAB_FUJIX)
+               s_ListBox.DoStart(TextureHeight + 15.0f + 10.0f + Margin, SearchListSize, CustomList.w / (Margin + TextureWidth), 1, OldSelected, &CustomList, false);
+       for(size_t i = 0; i < SearchListSize && s_CurCustomTab != ASSETS_TAB_FUJIX; ++i)
+       {
 		const SCustomItem *pItem = GetCustomItem(s_CurCustomTab, i);
 		if(pItem == nullptr)
 			continue;
@@ -557,9 +574,9 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		}
 	}
 
-	const int NewSelected = s_ListBox.DoEnd();
-	if(OldSelected != NewSelected)
-	{
+       const int NewSelected = s_CurCustomTab != ASSETS_TAB_FUJIX ? s_ListBox.DoEnd() : -1;
+       if(s_CurCustomTab != ASSETS_TAB_FUJIX && OldSelected != NewSelected)
+       {
 		if(GetCustomItem(s_CurCustomTab, NewSelected)->m_aName[0] != '\0')
 		{
 			if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
@@ -595,24 +612,26 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		}
 	}
 
-	// Quick search
-	MainView.HSplitBottom(ms_ButtonHeight, &MainView, &QuickSearch);
-	QuickSearch.VSplitLeft(220.0f, &QuickSearch, &DirectoryButton);
-	QuickSearch.HSplitTop(5.0f, nullptr, &QuickSearch);
-	if(Ui()->DoEditBox_Search(&s_aFilterInputs[s_CurCustomTab], &QuickSearch, 14.0f, !Ui()->IsPopupOpen() && !m_pClient->m_GameConsole.IsActive()))
-	{
-		gs_aInitCustomList[s_CurCustomTab] = true;
-	}
+       if(s_CurCustomTab != ASSETS_TAB_FUJIX)
+       {
+               // Quick search
+               MainView.HSplitBottom(ms_ButtonHeight, &MainView, &QuickSearch);
+               QuickSearch.VSplitLeft(220.0f, &QuickSearch, &DirectoryButton);
+               QuickSearch.HSplitTop(5.0f, nullptr, &QuickSearch);
+               if(Ui()->DoEditBox_Search(&s_aFilterInputs[s_CurCustomTab], &QuickSearch, 14.0f, !Ui()->IsPopupOpen() && !m_pClient->m_GameConsole.IsActive()))
+               {
+                       gs_aInitCustomList[s_CurCustomTab] = true;
+               }
 
-	DirectoryButton.HSplitTop(5.0f, nullptr, &DirectoryButton);
-	DirectoryButton.VSplitRight(175.0f, nullptr, &DirectoryButton);
-	DirectoryButton.VSplitRight(25.0f, &DirectoryButton, &ReloadButton);
-	DirectoryButton.VSplitRight(10.0f, &DirectoryButton, nullptr);
-	static CButtonContainer s_AssetsDirId;
-	if(DoButton_Menu(&s_AssetsDirId, Localize("Assets directory"), 0, &DirectoryButton))
-	{
-		char aBuf[IO_MAX_PATH_LENGTH];
-		char aBufFull[IO_MAX_PATH_LENGTH + 7];
+               DirectoryButton.HSplitTop(5.0f, nullptr, &DirectoryButton);
+               DirectoryButton.VSplitRight(175.0f, nullptr, &DirectoryButton);
+               DirectoryButton.VSplitRight(25.0f, &DirectoryButton, &ReloadButton);
+               DirectoryButton.VSplitRight(10.0f, &DirectoryButton, nullptr);
+               static CButtonContainer s_AssetsDirId;
+               if(DoButton_Menu(&s_AssetsDirId, Localize("Assets directory"), 0, &DirectoryButton))
+               {
+                       char aBuf[IO_MAX_PATH_LENGTH];
+                       char aBufFull[IO_MAX_PATH_LENGTH + 7];
 		if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
 			str_copy(aBufFull, "assets/entities");
 		else if(s_CurCustomTab == ASSETS_TAB_GAME)
@@ -639,8 +658,22 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	{
 		ClearCustomItems(s_CurCustomTab);
 	}
-	TextRender()->SetRenderFlags(0);
-	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+               TextRender()->SetRenderFlags(0);
+               TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+       }
+       else
+       {
+               CUIRect RecordButton, PlayButton;
+               MainView.HSplitBottom(ms_ButtonHeight * 2 + 5.0f, &MainView, &PlayButton);
+               MainView.HSplitBottom(ms_ButtonHeight, &MainView, &RecordButton);
+               static CButtonContainer s_RecordBtn, s_PlayBtn;
+               const char *pRecLabel = GameClient()->m_FujixTas.IsRecording() ? Localize("Stop") : Localize("Record");
+               const char *pPlayLabel = GameClient()->m_FujixTas.IsPlaying() ? Localize("Stop") : Localize("Play");
+               if(DoButton_Menu(&s_RecordBtn, pRecLabel, 0, &RecordButton))
+                       Console()->ExecuteLine("fujix_record");
+               if(DoButton_Menu(&s_PlayBtn, pPlayLabel, 0, &PlayButton))
+                       Console()->ExecuteLine("fujix_play");
+       }
 }
 
 void CMenus::ConchainAssetsEntities(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -125,15 +125,16 @@ void CGameClient::OnConsoleInit()
 					      &m_Sounds,
 					      &m_Voting,
 					      &m_Particles, // doesn't render anything, just updates all the particles
-					      &m_RaceDemo,
-					      &m_MapSounds,
-					      &m_Background, // render instead of m_MapLayersBackground when g_Config.m_ClOverlayEntities == 100
-					      &m_MapLayersBackground, // first to render
-					      &m_Particles.m_RenderTrail,
-					      &m_Particles.m_RenderTrailExtra,
-					      &m_Items,
-					      &m_Ghost,
-					      &m_Players,
+                                              &m_RaceDemo,
+                                              &m_MapSounds,
+                                              &m_Background, // render instead of m_MapLayersBackground when g_Config.m_ClOverlayEntities == 100
+                                              &m_MapLayersBackground, // first to render
+                                              &m_Particles.m_RenderTrail,
+                                              &m_Particles.m_RenderTrailExtra,
+                                              &m_Items,
+                                              &m_Ghost,
+                                             &m_FujixTas,
+                                              &m_Players,
 					      &m_MapLayersForeground,
 					      &m_Particles.m_RenderExplosions,
 					      &m_NamePlates,
@@ -511,10 +512,20 @@ void CGameClient::OnDummySwap()
 
 int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 {
-	if(!Dummy)
-	{
-		return m_Controls.SnapInput(pData);
-	}
+       if(!Dummy)
+       {
+               CNetObj_PlayerInput TasInput;
+               if(m_FujixTas.FetchPlaybackInput(&TasInput))
+               {
+                       mem_copy(pData, &TasInput, sizeof(TasInput));
+                       return sizeof(TasInput);
+               }
+
+               int Size = m_Controls.SnapInput(pData);
+               if(Size > 0)
+                       m_FujixTas.RecordInput((const CNetObj_PlayerInput *)pData, Client()->PredGameTick(g_Config.m_ClDummy));
+               return Size;
+       }
 	if(m_aLocalIds[!g_Config.m_ClDummy] < 0)
 	{
 		return 0;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -52,6 +52,7 @@
 #include "components/particles.h"
 #include "components/players.h"
 #include "components/race_demo.h"
+#include "components/fujix_tas.h"
 #include "components/scoreboard.h"
 #include "components/skins.h"
 #include "components/skins7.h"
@@ -169,10 +170,11 @@ public:
 
 	CMapSounds m_MapSounds;
 
-	CRaceDemo m_RaceDemo;
-	CGhost m_Ghost;
+        CRaceDemo m_RaceDemo;
+        CGhost m_Ghost;
+       CFujixTas m_FujixTas;
 
-	CTooltips m_Tooltips;
+        CTooltips m_Tooltips;
 
 private:
 	std::vector<class CComponent *> m_vpAll;


### PR DESCRIPTION
## Summary
- create custom format recorder/player for FUJIX TAS
- save player inputs per map in `.fjx` files
- add toggleable Play/Record buttons
- hook playback/recording into game input pipeline

## Testing
- `scripts/fix_style.py` *(fails: clang-format missing)*
- `cmake -S . -B build` *(fails: glslangValidator not found)*


------
https://chatgpt.com/codex/tasks/task_e_684447c163b8832c8b225f750784e872