### PR TITLE
Improve FUJIX TAS playback start

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2382,6 +2382,8 @@ if(CLIENT)
     components/players.h
     components/race_demo.cpp
     components/race_demo.h
+    components/fujix_tas.cpp
+    components/fujix_tas.h
     components/scoreboard.cpp
     components/scoreboard.h
     components/skins.cpp

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -647,6 +647,8 @@ MACRO_CONFIG_STR(ClMenuMap, cl_menu_map, 100, "auto", CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClRotationRadius, cl_rotation_radius, 30, 1, 500, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera rotation radius")
 MACRO_CONFIG_INT(ClRotationSpeed, cl_rotation_speed, 40, 1, 120, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera rotations in seconds")
 MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 40, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera speed")
+MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Record FUJIX TAS")
+MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -1,0 +1,148 @@
+#include "fujix_tas.h"
+
+#include <engine/shared/config.h>
+#include <engine/storage.h>
+#include <engine/console.h>
+#include <engine/client.h>
+#include <game/client/gameclient.h>
+
+const char *CFujixTas::ms_pFujixDir = "fujix";
+
+CFujixTas::CFujixTas()
+{
+    m_Recording = false;
+    m_Playing = false;
+    m_StartTick = 0;
+    m_PlayStartTick = 0;
+    m_File = nullptr;
+    m_PlayIndex = 0;
+    m_aFilename[0] = '\0';
+}
+
+void CFujixTas::GetPath(char *pBuf, int Size) const
+{
+    const char *pMap = Client()->GetCurrentMap();
+    str_format(pBuf, Size, "%s/%s.fjx", ms_pFujixDir, pMap);
+}
+
+void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
+{
+    if(!m_Recording || !m_File)
+        return;
+    SEntry e{Tick - m_StartTick, *pInput};
+    io_write(m_File, &e, sizeof(e));
+}
+
+bool CFujixTas::FetchEntry(CNetObj_PlayerInput *pInput)
+{
+    if(!m_Playing || m_PlayIndex >= (int)m_vEntries.size())
+        return false;
+    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    if(m_PlayStartTick + m_vEntries[m_PlayIndex].m_Tick > PredTick)
+        return false;
+
+    *pInput = m_vEntries[m_PlayIndex].m_Input;
+    m_PlayIndex++;
+    if(m_PlayIndex >= (int)m_vEntries.size())
+        m_Playing = false;
+    return true;
+}
+
+void CFujixTas::StartRecord()
+{
+    if(m_Recording)
+        return;
+    GetPath(m_aFilename, sizeof(m_aFilename));
+    Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
+    m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    if(!m_File)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for recording");
+        return;
+    }
+    m_StartTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_Recording = true;
+}
+
+void CFujixTas::StopRecord()
+{
+    if(!m_Recording)
+        return;
+    if(m_File)
+        io_close(m_File);
+    m_File = nullptr;
+    m_Recording = false;
+}
+
+void CFujixTas::StartPlay()
+{
+    if(m_Playing)
+        StopPlay();
+
+    char aPath[IO_MAX_PATH_LENGTH];
+    GetPath(aPath, sizeof(aPath));
+    IOHANDLE File = Storage()->OpenFile(aPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    if(!File)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for playback");
+        return;
+    }
+
+    m_vEntries.clear();
+    SEntry e;
+    while(io_read(File, &e, sizeof(e)) == sizeof(e))
+        m_vEntries.push_back(e);
+    io_close(File);
+
+    m_PlayIndex = 0;
+    m_PlayStartTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_Playing = !m_vEntries.empty();
+}
+
+void CFujixTas::StopPlay()
+{
+    m_Playing = false;
+    m_vEntries.clear();
+    m_PlayIndex = 0;
+    m_PlayStartTick = 0;
+}
+
+bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
+{
+    return FetchEntry(pInput);
+}
+
+void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
+{
+    RecordEntry(pInput, Tick);
+}
+
+void CFujixTas::ConRecord(IConsole::IResult *pResult, void *pUserData)
+{
+    CFujixTas *pSelf = static_cast<CFujixTas *>(pUserData);
+    if(pSelf->m_Recording)
+        pSelf->StopRecord();
+    else
+        pSelf->StartRecord();
+}
+
+void CFujixTas::ConPlay(IConsole::IResult *pResult, void *pUserData)
+{
+    CFujixTas *pSelf = static_cast<CFujixTas *>(pUserData);
+    if(pSelf->m_Playing)
+        pSelf->StopPlay();
+    else
+        pSelf->StartPlay();
+}
+
+void CFujixTas::OnConsoleInit()
+{
+    Console()->Register("fujix_record", "", CFGFLAG_CLIENT, ConRecord, this, "Start/stop FUJIX TAS recording");
+    Console()->Register("fujix_play", "", CFGFLAG_CLIENT, ConPlay, this, "Play FUJIX TAS for current map");
+}
+
+void CFujixTas::OnMapLoad()
+{
+    Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
+}
+

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -1,0 +1,55 @@
+#ifndef GAME_CLIENT_COMPONENTS_FUJIX_TAS_H
+#define GAME_CLIENT_COMPONENTS_FUJIX_TAS_H
+
+#include <game/client/component.h>
+#include <engine/storage.h>
+#include <engine/console.h>
+#include <game/generated/protocol.h>
+#include <vector>
+
+class CFujixTas : public CComponent
+{
+public:
+    static const char *ms_pFujixDir;
+
+private:
+    struct SEntry
+    {
+        int m_Tick;
+        CNetObj_PlayerInput m_Input;
+    };
+
+    bool m_Recording;
+    bool m_Playing;
+    int m_StartTick;
+    int m_PlayStartTick;
+    char m_aFilename[IO_MAX_PATH_LENGTH];
+    IOHANDLE m_File;
+    std::vector<SEntry> m_vEntries;
+    int m_PlayIndex;
+
+    void GetPath(char *pBuf, int Size) const;
+    void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
+    bool FetchEntry(CNetObj_PlayerInput *pInput);
+
+    static void ConRecord(IConsole::IResult *pResult, void *pUserData);
+    static void ConPlay(IConsole::IResult *pResult, void *pUserData);
+
+public:
+    CFujixTas();
+    virtual int Sizeof() const override { return sizeof(*this); }
+
+    virtual void OnConsoleInit() override;
+    virtual void OnMapLoad() override;
+
+    void StartRecord();
+    void StopRecord();
+    void StartPlay();
+    void StopPlay();
+    bool IsRecording() const { return m_Recording; }
+    bool IsPlaying() const { return m_Playing; }
+    bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
+    void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
+};
+
+#endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -724,10 +724,11 @@ public:
 		SETTINGS_CONTROLS,
 		SETTINGS_GRAPHICS,
 		SETTINGS_SOUND,
-		SETTINGS_DDNET,
-		SETTINGS_ASSETS,
+               SETTINGS_DDNET,
+               SETTINGS_ASSETS,
+               SETTINGS_FUJIX,
 
-		SETTINGS_LENGTH,
+               SETTINGS_LENGTH,
 
 		BIG_TAB_NEWS = 0,
 		BIG_TAB_INTERNET,
@@ -851,8 +852,9 @@ private:
 	void RenderGhost(CUIRect MainView);
 
 	// found in menus_settings.cpp
-	void RenderSettingsDDNet(CUIRect MainView);
-	void RenderSettingsAppearance(CUIRect MainView);
+        void RenderSettingsDDNet(CUIRect MainView);
+       void RenderSettingsFujix(CUIRect MainView);
+        void RenderSettingsAppearance(CUIRect MainView);
 	bool RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alpha, float DarkestLight);
 
 	CServerProcess m_ServerProcess;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1961,9 +1961,10 @@ void CMenus::RenderSettings(CUIRect MainView)
 		Localize("Appearance"),
 		Localize("Controls"),
 		Localize("Graphics"),
-		Localize("Sound"),
-		Localize("DDNet"),
-		Localize("Assets")};
+               Localize("Sound"),
+               Localize("DDNet"),
+               Localize("Assets"),
+               "FUJIX"};
 	static CButtonContainer s_aTabButtons[SETTINGS_LENGTH];
 
 	for(int i = 0; i < SETTINGS_LENGTH; i++)
@@ -2022,12 +2023,17 @@ void CMenus::RenderSettings(CUIRect MainView)
 		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_DDNET);
 		RenderSettingsDDNet(MainView);
 	}
-	else if(g_Config.m_UiSettingsPage == SETTINGS_ASSETS)
-	{
-		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_ASSETS);
-		RenderSettingsCustom(MainView);
-	}
-	else
+       else if(g_Config.m_UiSettingsPage == SETTINGS_ASSETS)
+       {
+               GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_ASSETS);
+               RenderSettingsCustom(MainView);
+       }
+       else if(g_Config.m_UiSettingsPage == SETTINGS_FUJIX)
+       {
+               GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_ASSETS);
+               RenderSettingsFujix(MainView);
+       }
+       else
 	{
 		dbg_assert(false, "ui_settings_page invalid");
 	}
@@ -3453,6 +3459,24 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 #endif
+}
+
+void CMenus::RenderSettingsFujix(CUIRect MainView)
+{
+       CUIRect RecordButton, PlayButton;
+       MainView.HSplitTop(10.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RecordButton, &MainView);
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &PlayButton, &MainView);
+
+       static CButtonContainer s_RecordBtn, s_PlayBtn;
+       const char *pRecLabel = GameClient()->m_FujixTas.IsRecording() ? Localize("Stop") : Localize("Record");
+       const char *pPlayLabel = GameClient()->m_FujixTas.IsPlaying() ? Localize("Stop") : Localize("Play");
+
+       if(DoButton_Menu(&s_RecordBtn, pRecLabel, 0, &RecordButton))
+               Console()->ExecuteLine("fujix_record");
+       if(DoButton_Menu(&s_PlayBtn, pPlayLabel, 0, &PlayButton))
+               Console()->ExecuteLine("fujix_play");
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -125,15 +125,16 @@ void CGameClient::OnConsoleInit()
 					      &m_Sounds,
 					      &m_Voting,
 					      &m_Particles, // doesn't render anything, just updates all the particles
-					      &m_RaceDemo,
-					      &m_MapSounds,
-					      &m_Background, // render instead of m_MapLayersBackground when g_Config.m_ClOverlayEntities == 100
-					      &m_MapLayersBackground, // first to render
-					      &m_Particles.m_RenderTrail,
-					      &m_Particles.m_RenderTrailExtra,
-					      &m_Items,
-					      &m_Ghost,
-					      &m_Players,
+                                              &m_RaceDemo,
+                                              &m_MapSounds,
+                                              &m_Background, // render instead of m_MapLayersBackground when g_Config.m_ClOverlayEntities == 100
+                                              &m_MapLayersBackground, // first to render
+                                              &m_Particles.m_RenderTrail,
+                                              &m_Particles.m_RenderTrailExtra,
+                                              &m_Items,
+                                              &m_Ghost,
+                                             &m_FujixTas,
+                                              &m_Players,
 					      &m_MapLayersForeground,
 					      &m_Particles.m_RenderExplosions,
 					      &m_NamePlates,
@@ -511,10 +512,20 @@ void CGameClient::OnDummySwap()
 
 int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 {
-	if(!Dummy)
-	{
-		return m_Controls.SnapInput(pData);
-	}
+       if(!Dummy)
+       {
+               CNetObj_PlayerInput TasInput;
+               if(m_FujixTas.FetchPlaybackInput(&TasInput))
+               {
+                       mem_copy(pData, &TasInput, sizeof(TasInput));
+                       return sizeof(TasInput);
+               }
+
+               int Size = m_Controls.SnapInput(pData);
+               if(Size > 0)
+                       m_FujixTas.RecordInput((const CNetObj_PlayerInput *)pData, Client()->PredGameTick(g_Config.m_ClDummy));
+               return Size;
+       }
 	if(m_aLocalIds[!g_Config.m_ClDummy] < 0)
 	{
 		return 0;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -52,6 +52,7 @@
 #include "components/particles.h"
 #include "components/players.h"
 #include "components/race_demo.h"
+#include "components/fujix_tas.h"
 #include "components/scoreboard.h"
 #include "components/skins.h"
 #include "components/skins7.h"
@@ -169,10 +170,11 @@ public:
 
 	CMapSounds m_MapSounds;
 
-	CRaceDemo m_RaceDemo;
-	CGhost m_Ghost;
+        CRaceDemo m_RaceDemo;
+        CGhost m_Ghost;
+       CFujixTas m_FujixTas;
 
-	CTooltips m_Tooltips;
+        CTooltips m_Tooltips;
 
 private:
 	std::vector<class CComponent *> m_vpAll;


### PR DESCRIPTION
## Summary
- adjust play start tick so first recorded input isn't delayed

## Testing
- `scripts/fix_style.py` *(fails: Found no clang-format 10)*
- `cmake -S . -B build` *(fails: glslangValidator binary was not found)*
- `cmake --build build --target run_tests` *(fails: Makefile: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684447c163b8832c8b225f750784e872