### PR TITLE
Fix Fujix TAS playback accuracy

### DIFF
--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -27,10 +27,12 @@ private:
     IOHANDLE m_File;
     std::vector<SEntry> m_vEntries;
     int m_PlayIndex;
+    CNetObj_PlayerInput m_CurrentInput;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
     bool FetchEntry(CNetObj_PlayerInput *pInput);
+    void UpdatePlaybackInput();
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
## Summary
- keep the last TAS input between recorded ticks
- initialize/reset playback input state

## Testing
- `python3 scripts/check_header_guards.py`
- `python3 scripts/check_unused_header_files.py`
- `python3 scripts/check_config_variables.py` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844d85eb7d0832c978cc5d6fc002f50