### PR TITLE
Fix phantom input recording

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -5,6 +5,11 @@
 #include <engine/console.h>
 #include <engine/client.h>
 #include <game/client/gameclient.h>
+#include <game/client/render.h>
+#include <game/client/animstate.h>
+#include <game/gamecore.h>
+#include <game/client/components/players.h>
+#include <base/system.h>
 
 const char *CFujixTas::ms_pFujixDir = "fujix";
 
@@ -17,6 +22,10 @@ CFujixTas::CFujixTas()
     m_File = nullptr;
     m_PlayIndex = 0;
     m_aFilename[0] = '\0';
+    mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
+    m_PhantomActive = false;
+    m_PhantomTick = 0;
+    mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
 }
 
 void CFujixTas::GetPath(char *pBuf, int Size) const
@@ -33,19 +42,36 @@ void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
     io_write(m_File, &e, sizeof(e));
 }
 
+
 bool CFujixTas::FetchEntry(CNetObj_PlayerInput *pInput)
 {
-    if(!m_Playing || m_PlayIndex >= (int)m_vEntries.size())
-        return false;
-    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
-    if(m_PlayStartTick + m_vEntries[m_PlayIndex].m_Tick > PredTick)
+    if(!m_Playing)
         return false;
 
-    *pInput = m_vEntries[m_PlayIndex].m_Input;
-    m_PlayIndex++;
-    if(m_PlayIndex >= (int)m_vEntries.size())
-        m_Playing = false;
+    UpdatePlaybackInput();
+    *pInput = m_CurrentInput;
     return true;
+}
+
+void CFujixTas::UpdatePlaybackInput()
+{
+    if(!m_Playing)
+        return;
+
+    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    while(m_PlayIndex < (int)m_vEntries.size() &&
+          m_PlayStartTick + m_vEntries[m_PlayIndex].m_Tick <= PredTick)
+    {
+        m_CurrentInput = m_vEntries[m_PlayIndex].m_Input;
+        m_PlayIndex++;
+    }
+
+    if(m_PlayIndex >= (int)m_vEntries.size() &&
+       PredTick >= m_PlayStartTick + m_vEntries.back().m_Tick)
+    {
+        m_Playing = false;
+        g_Config.m_ClFujixTasPlay = 0;
+    }
 }
 
 void CFujixTas::StartRecord()
@@ -64,6 +90,19 @@ void CFujixTas::StartRecord()
     // the upcoming OnSnapInput call
     m_StartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_Recording = true;
+    g_Config.m_ClFujixTasRecord = 1;
+
+    // init phantom
+    if(GameClient()->m_Snap.m_LocalClientId >= 0)
+    {
+        m_PhantomCore = GameClient()->m_PredictedChar;
+        m_PhantomPrevCore = m_PhantomCore;
+        m_PhantomCore.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        m_PhantomRenderInfo = GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_RenderInfo;
+    }
+    m_PhantomTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
+    m_PhantomActive = true;
 }
 
 void CFujixTas::StopRecord()
@@ -74,6 +113,8 @@ void CFujixTas::StopRecord()
         io_close(m_File);
     m_File = nullptr;
     m_Recording = false;
+    g_Config.m_ClFujixTasRecord = 0;
+    m_PhantomActive = false;
 }
 
 void CFujixTas::StartPlay()
@@ -101,14 +142,21 @@ void CFujixTas::StartPlay()
     // first stored input is applied exactly when OnSnapInput runs
     m_PlayStartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_Playing = !m_vEntries.empty();
+    if(m_Playing)
+    {
+        g_Config.m_ClFujixTasPlay = 1;
+        m_CurrentInput = m_vEntries[0].m_Input;
+    }
 }
 
 void CFujixTas::StopPlay()
 {
     m_Playing = false;
+    g_Config.m_ClFujixTasPlay = 0;
     m_vEntries.clear();
     m_PlayIndex = 0;
     m_PlayStartTick = 0;
+    mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
 }
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
@@ -118,6 +166,8 @@ bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
 
 void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
 {
+    if(m_Recording)
+        UpdatePhantomInput(pInput);
     RecordEntry(pInput, Tick);
 }
 
@@ -148,5 +198,84 @@ void CFujixTas::OnConsoleInit()
 void CFujixTas::OnMapLoad()
 {
     Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
+}
+
+void CFujixTas::UpdatePhantomInput(const CNetObj_PlayerInput *pInput)
+{
+    if(m_PhantomActive)
+        m_PhantomInput = *pInput;
+}
+
+void CFujixTas::TickPhantom()
+{
+    if(!m_PhantomActive)
+        return;
+
+    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    while(m_PhantomTick < PredTick)
+    {
+        m_PhantomPrevCore = m_PhantomCore;
+        m_PhantomCore.m_Input = m_PhantomInput;
+        m_PhantomCore.Tick(true);
+        m_PhantomCore.Move();
+        m_PhantomCore.Quantize();
+        ++m_PhantomTick;
+    }
+}
+
+void CFujixTas::CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar)
+{
+    CNetObj_CharacterCore CCore;
+    Core.Write(&CCore);
+    mem_zero(pChar, sizeof(*pChar));
+    pChar->m_X = CCore.m_X;
+    pChar->m_Y = CCore.m_Y;
+    pChar->m_VelX = CCore.m_VelX;
+    pChar->m_VelY = CCore.m_VelY;
+    pChar->m_Angle = CCore.m_Angle;
+    pChar->m_Direction = CCore.m_Direction;
+    pChar->m_Weapon = Core.m_ActiveWeapon;
+    pChar->m_HookState = CCore.m_HookState;
+    pChar->m_HookTick = CCore.m_HookTick;
+    pChar->m_HookX = CCore.m_HookX;
+    pChar->m_HookY = CCore.m_HookY;
+    pChar->m_HookDx = CCore.m_HookDx;
+    pChar->m_HookDy = CCore.m_HookDy;
+    pChar->m_HookedPlayer = CCore.m_HookedPlayer;
+    pChar->m_Jumped = CCore.m_Jumped;
+    pChar->m_Tick = Client()->GameTick(g_Config.m_ClDummy);
+    pChar->m_AttackTick = Core.m_HookTick; // approximate
+}
+
+void CFujixTas::OnUpdate()
+{
+    if(g_Config.m_ClFujixTasRecord && !m_Recording)
+        StartRecord();
+    else if(!g_Config.m_ClFujixTasRecord && m_Recording)
+        StopRecord();
+
+    if(g_Config.m_ClFujixTasPlay && !m_Playing)
+        StartPlay();
+    else if(!g_Config.m_ClFujixTasPlay && m_Playing)
+        StopPlay();
+
+    TickPhantom();
+
+    if(m_PhantomActive)
+        GameClient()->m_Camera.m_Center = m_PhantomCore.m_Pos;
+}
+
+void CFujixTas::OnRender()
+{
+    if(!m_PhantomActive)
+        return;
+
+    CNetObj_Character Prev, Curr;
+    CoreToCharacter(m_PhantomPrevCore, &Prev);
+    CoreToCharacter(m_PhantomCore, &Curr);
+
+    GameClient()->m_Players.RenderHook(&Prev, &Curr, &m_PhantomRenderInfo, -2);
+    GameClient()->m_Players.RenderHookCollLine(&Prev, &Curr, -2);
+    GameClient()->m_Players.RenderPlayer(&Prev, &Curr, &m_PhantomRenderInfo, -2);
 }
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -5,6 +5,8 @@
 #include <engine/storage.h>
 #include <engine/console.h>
 #include <game/generated/protocol.h>
+#include <game/gamecore.h>
+#include <game/client/render.h>
 #include <vector>
 
 class CFujixTas : public CComponent
@@ -27,10 +29,22 @@ private:
     IOHANDLE m_File;
     std::vector<SEntry> m_vEntries;
     int m_PlayIndex;
+    CNetObj_PlayerInput m_CurrentInput;
+
+    bool m_PhantomActive;
+    int m_PhantomTick;
+    CNetObj_PlayerInput m_PhantomInput;
+    CCharacterCore m_PhantomCore;
+    CCharacterCore m_PhantomPrevCore;
+    CTeeRenderInfo m_PhantomRenderInfo;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
     bool FetchEntry(CNetObj_PlayerInput *pInput);
+    void UpdatePlaybackInput();
+    void UpdatePhantomInput(const CNetObj_PlayerInput *pInput);
+    void TickPhantom();
+    void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar);
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);
@@ -41,6 +55,8 @@ public:
 
     virtual void OnConsoleInit() override;
     virtual void OnMapLoad() override;
+    virtual void OnUpdate() override;
+    virtual void OnRender() override;
 
     void StartRecord();
     void StopRecord();

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -9,7 +9,8 @@
 
 class CPlayers : public CComponent
 {
-	friend class CGhost;
+        friend class CGhost;
+        friend class CFujixTas;
 
 	void RenderHand6(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);
 	void RenderHand7(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -521,10 +521,35 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
                        return sizeof(TasInput);
                }
 
-               int Size = m_Controls.SnapInput(pData);
+               CNetObj_PlayerInput LocalInput;
+               int Size = m_Controls.SnapInput((int *)&LocalInput);
+               int Tick = Client()->PredGameTick(g_Config.m_ClDummy);
+
                if(Size > 0)
-                       m_FujixTas.RecordInput((const CNetObj_PlayerInput *)pData, Client()->PredGameTick(g_Config.m_ClDummy));
-               return Size;
+               {
+                      if(m_FujixTas.IsRecording())
+                      {
+                              m_FujixTas.RecordInput(&LocalInput, Tick);
+                              CNetObj_PlayerInput NullInput;
+                              mem_zero(&NullInput, sizeof(NullInput));
+                              mem_copy(pData, &NullInput, sizeof(NullInput));
+                              return sizeof(NullInput);
+                      }
+
+                       m_FujixTas.RecordInput(&LocalInput, Tick);
+                       mem_copy(pData, &LocalInput, sizeof(LocalInput));
+                       return Size;
+               }
+
+               if(m_FujixTas.IsRecording())
+               {
+                       CNetObj_PlayerInput NullInput;
+                       mem_zero(&NullInput, sizeof(NullInput));
+                       mem_copy(pData, &NullInput, sizeof(NullInput));
+                       return sizeof(NullInput);
+               }
+
+               return 0;
        }
 	if(m_aLocalIds[!g_Config.m_ClDummy] < 0)
 	{


### PR DESCRIPTION
## Summary
- update Fujix menu actions to toggle config flags
- show phantom hook and move camera to phantom
- convert phantom core to net character for rendering
- allow FujixTas to render using private player rendering helpers

## Testing
- `python3 scripts/check_header_guards.py`
- `python3 scripts/check_unused_header_files.py`
- `python3 scripts/check_config_variables.py`
- `bash scripts/android/cmake_android.sh arm64 DDNet org.ddnet.client Debug build-android-arm64` *(fails: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6844d85eb7d0832c978cc5d6fc002f50