### PR TITLE
Improve TAS stop accuracy

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -649,6 +649,9 @@ MACRO_CONFIG_INT(ClRotationSpeed, cl_rotation_speed, 40, 1, 120, CFGFLAG_CLIENT 
 MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 40, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera speed")
 MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Record FUJIX TAS")
 MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
+MACRO_CONFIG_INT(ClFujixTasRewind, cl_fujix_tas_rewind, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Rollback phantom on tiles")
+MACRO_CONFIG_INT(ClFujixTasRewindTicks, cl_fujix_tas_rewind_ticks, 10, 5, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to rollback phantom")
+MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 10, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Phantom ticks per second while recording")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -5,6 +5,12 @@
 #include <engine/console.h>
 #include <engine/client.h>
 #include <game/client/gameclient.h>
+#include <game/client/render.h>
+#include <game/client/animstate.h>
+#include <base/math.h>
+#include <game/gamecore.h>
+#include <game/client/components/players.h>
+#include <base/system.h>
 
 const char *CFujixTas::ms_pFujixDir = "fujix";
 
@@ -16,7 +22,19 @@ CFujixTas::CFujixTas()
     m_PlayStartTick = 0;
     m_File = nullptr;
     m_PlayIndex = 0;
+    m_LastRecordTick = -1;
     m_aFilename[0] = '\0';
+    mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
+    m_StopPending = false;
+    m_StopTick = -1;
+    m_PhantomActive = false;
+    m_PhantomTick = 0;
+    mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
+    m_PhantomFreezeTime = 0;
+    m_PhantomStep = 1;
+    m_LastPredTick = 0;
+    m_PhantomHistory.clear();
+    m_PendingInputs.clear();
 }
 
 void CFujixTas::GetPath(char *pBuf, int Size) const
@@ -31,21 +49,44 @@ void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
         return;
     SEntry e{Tick - m_StartTick, *pInput};
     io_write(m_File, &e, sizeof(e));
+    m_vEntries.push_back(e);
 }
+
 
 bool CFujixTas::FetchEntry(CNetObj_PlayerInput *pInput)
 {
-    if(!m_Playing || m_PlayIndex >= (int)m_vEntries.size())
-        return false;
-    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
-    if(m_PlayStartTick + m_vEntries[m_PlayIndex].m_Tick > PredTick)
+    if(!m_Playing)
         return false;
 
-    *pInput = m_vEntries[m_PlayIndex].m_Input;
-    m_PlayIndex++;
-    if(m_PlayIndex >= (int)m_vEntries.size())
-        m_Playing = false;
+    UpdatePlaybackInput();
+    *pInput = m_CurrentInput;
+
+    // also update the local control state so prediction uses the TAS input
+    GameClient()->m_Controls.m_aInputData[g_Config.m_ClDummy] = m_CurrentInput;
+    GameClient()->m_Controls.m_aLastData[g_Config.m_ClDummy] = m_CurrentInput;
+
     return true;
+}
+
+void CFujixTas::UpdatePlaybackInput()
+{
+    if(!m_Playing)
+        return;
+
+    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    while(m_PlayIndex < (int)m_vEntries.size() &&
+          m_PlayStartTick + m_vEntries[m_PlayIndex].m_Tick <= PredTick)
+    {
+        m_CurrentInput = m_vEntries[m_PlayIndex].m_Input;
+        m_PlayIndex++;
+    }
+
+    if(m_PlayIndex >= (int)m_vEntries.size() &&
+       PredTick >= m_PlayStartTick + m_vEntries.back().m_Tick)
+    {
+        m_Playing = false;
+        g_Config.m_ClFujixTasPlay = 0;
+    }
 }
 
 void CFujixTas::StartRecord()
@@ -63,10 +104,31 @@ void CFujixTas::StartRecord()
     // start recording on the next predicted tick to align with
     // the upcoming OnSnapInput call
     m_StartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
+    m_LastRecordTick = m_StartTick - 1;
     m_Recording = true;
+    g_Config.m_ClFujixTasRecord = 1;
+    m_vEntries.clear();
+    m_PhantomHistory.clear();
+    m_PendingInputs.clear();
+
+    // init phantom
+    if(GameClient()->m_Snap.m_LocalClientId >= 0)
+    {
+        m_PhantomCore = GameClient()->m_PredictedChar;
+        m_PhantomPrevCore = m_PhantomCore;
+        m_PhantomCore.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        m_PhantomRenderInfo = GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_RenderInfo;
+    }
+    m_PhantomTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_PhantomStep = maximum(1, Client()->GameTickSpeed() / g_Config.m_ClFujixTasPhantomTps);
+    m_LastPredTick = m_PhantomTick;
+    mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
+    m_PhantomFreezeTime = 0;
+    m_PhantomActive = true;
+    m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
 }
 
-void CFujixTas::StopRecord()
+void CFujixTas::FinishRecord()
 {
     if(!m_Recording)
         return;
@@ -74,6 +136,26 @@ void CFujixTas::StopRecord()
         io_close(m_File);
     m_File = nullptr;
     m_Recording = false;
+    g_Config.m_ClFujixTasRecord = 0;
+    m_PhantomActive = false;
+    m_PendingInputs.clear();
+    m_LastRecordTick = -1;
+    m_StopPending = false;
+    m_StopTick = -1;
+}
+
+void CFujixTas::StopRecord()
+{
+    if(!m_Recording || m_StopPending)
+        return;
+    m_StopPending = true;
+    m_StopTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
+}
+
+void CFujixTas::MaybeFinishRecord()
+{
+    if(m_StopPending && Client()->PredGameTick(g_Config.m_ClDummy) >= m_StopTick)
+        FinishRecord();
 }
 
 void CFujixTas::StartPlay()
@@ -101,14 +183,21 @@ void CFujixTas::StartPlay()
     // first stored input is applied exactly when OnSnapInput runs
     m_PlayStartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_Playing = !m_vEntries.empty();
+    if(m_Playing)
+    {
+        g_Config.m_ClFujixTasPlay = 1;
+        m_CurrentInput = m_vEntries[0].m_Input;
+    }
 }
 
 void CFujixTas::StopPlay()
 {
     m_Playing = false;
+    g_Config.m_ClFujixTasPlay = 0;
     m_vEntries.clear();
     m_PlayIndex = 0;
     m_PlayStartTick = 0;
+    mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
 }
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
@@ -118,6 +207,11 @@ bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
 
 void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
 {
+    if(Tick == m_LastRecordTick)
+        return;
+    m_LastRecordTick = Tick;
+    if(m_Recording)
+        m_PendingInputs.push_back({Tick, *pInput});
     RecordEntry(pInput, Tick);
 }
 
@@ -148,5 +242,250 @@ void CFujixTas::OnConsoleInit()
 void CFujixTas::OnMapLoad()
 {
     Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
+}
+
+void CFujixTas::RewriteFile()
+{
+    if(!m_File)
+        return;
+    io_close(m_File);
+    m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    for(const auto &e : m_vEntries)
+        io_write(m_File, &e, sizeof(e));
+}
+
+void CFujixTas::RollbackPhantom(int Ticks)
+{
+    if(Ticks <= 0 || m_PhantomHistory.empty())
+        return;
+    int Target = m_PhantomTick - Ticks;
+    if(Target < m_StartTick)
+        Target = m_StartTick;
+    SPhantomState State = m_PhantomHistory.front();
+    for(const auto &s : m_PhantomHistory)
+    {
+        if(s.m_Tick <= Target)
+            State = s;
+        else
+            break;
+    }
+    while(!m_PhantomHistory.empty() && m_PhantomHistory.back().m_Tick > Target)
+        m_PhantomHistory.pop_back();
+    while(!m_vEntries.empty() && m_StartTick + m_vEntries.back().m_Tick > Target)
+        m_vEntries.pop_back();
+    while(!m_PendingInputs.empty() && m_PendingInputs.back().m_Tick > Target)
+        m_PendingInputs.pop_back();
+    m_PhantomCore = State.m_Core;
+    m_PhantomPrevCore = State.m_PrevCore;
+    m_PhantomInput = State.m_Input;
+    m_PhantomFreezeTime = State.m_FreezeTime;
+    m_PhantomTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+    RewriteFile();
+}
+
+void CFujixTas::PhantomFreeze(int Seconds)
+{
+    if(Seconds <= 0)
+        Seconds = g_Config.m_SvFreezeDelay;
+    int Time = Seconds * Client()->GameTickSpeed();
+    if(m_PhantomFreezeTime >= Time)
+        return;
+    m_PhantomFreezeTime = Time;
+    m_PhantomCore.m_FreezeStart = m_PhantomTick;
+    m_PhantomCore.m_FreezeEnd = m_PhantomCore.m_DeepFrozen ? -1 : m_PhantomTick + m_PhantomFreezeTime;
+}
+
+void CFujixTas::PhantomUnfreeze()
+{
+    if(m_PhantomFreezeTime > 0)
+    {
+        m_PhantomFreezeTime = 0;
+        m_PhantomCore.m_FreezeStart = 0;
+        m_PhantomCore.m_FreezeEnd = m_PhantomCore.m_DeepFrozen ? -1 : 0;
+    }
+}
+
+bool CFujixTas::HandlePhantomTiles(int MapIndex)
+{
+    bool Rewound = false;
+
+    if(MapIndex < 0)
+        return false;
+
+    int Tile = Collision()->GetTileIndex(MapIndex);
+    int FTile = Collision()->GetFrontTileIndex(MapIndex);
+    int SwitchType = Collision()->GetSwitchType(MapIndex);
+
+    int Tele = Collision()->IsTeleport(MapIndex);
+    if(Tele && !Collision()->TeleOuts(Tele - 1).empty())
+    {
+        if(m_Recording && g_Config.m_ClFujixTasRewind)
+        {
+            RollbackPhantom(g_Config.m_ClFujixTasRewindTicks);
+            Rewound = true;
+        }
+        else
+            m_PhantomCore.m_Pos = Collision()->TeleOuts(Tele - 1)[0];
+    }
+
+    int EvilTele = Collision()->IsEvilTeleport(MapIndex);
+    if(EvilTele && !Collision()->TeleOuts(EvilTele - 1).empty())
+    {
+        if(m_Recording && g_Config.m_ClFujixTasRewind)
+        {
+            RollbackPhantom(g_Config.m_ClFujixTasRewindTicks);
+            Rewound = true;
+        }
+        else
+            m_PhantomCore.m_Pos = Collision()->TeleOuts(EvilTele - 1)[0];
+    }
+
+    if(Tile == TILE_FREEZE || FTile == TILE_FREEZE || SwitchType == TILE_FREEZE)
+    {
+        if(m_Recording && g_Config.m_ClFujixTasRewind)
+        {
+            RollbackPhantom(g_Config.m_ClFujixTasRewindTicks);
+            Rewound = true;
+        }
+        else
+            PhantomFreeze(Collision()->GetSwitchDelay(MapIndex));
+    }
+    else if(Tile == TILE_UNFREEZE || FTile == TILE_UNFREEZE || SwitchType == TILE_DUNFREEZE)
+    {
+        PhantomUnfreeze();
+    }
+
+    if(Tile == TILE_DFREEZE || FTile == TILE_DFREEZE || SwitchType == TILE_DFREEZE)
+    {
+        if(m_Recording && g_Config.m_ClFujixTasRewind)
+        {
+            RollbackPhantom(g_Config.m_ClFujixTasRewindTicks);
+            Rewound = true;
+        }
+        else
+            m_PhantomCore.m_DeepFrozen = true;
+    }
+    else if(Tile == TILE_DUNFREEZE || FTile == TILE_DUNFREEZE || SwitchType == TILE_DUNFREEZE)
+    {
+        m_PhantomCore.m_DeepFrozen = false;
+    }
+
+    if(Tile == TILE_LFREEZE || FTile == TILE_LFREEZE || SwitchType == TILE_LFREEZE)
+    {
+        if(m_Recording && g_Config.m_ClFujixTasRewind)
+        {
+            RollbackPhantom(g_Config.m_ClFujixTasRewindTicks);
+            Rewound = true;
+        }
+        else
+            m_PhantomCore.m_LiveFrozen = true;
+    }
+    else if(Tile == TILE_LUNFREEZE || FTile == TILE_LUNFREEZE || SwitchType == TILE_LUNFREEZE)
+    {
+        m_PhantomCore.m_LiveFrozen = false;
+    }
+
+    if(SwitchType == TILE_JUMP)
+    {
+        int NewJumps = Collision()->GetSwitchDelay(MapIndex);
+        if(NewJumps == 255)
+            NewJumps = -1;
+        if(NewJumps != m_PhantomCore.m_Jumps)
+            m_PhantomCore.m_Jumps = NewJumps;
+    }
+
+    return Rewound;
+}
+
+void CFujixTas::TickPhantom()
+{
+    if(!m_PhantomActive)
+        return;
+
+    int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    while(m_PhantomTick + m_PhantomStep <= PredTick)
+    {
+        m_PhantomPrevCore = m_PhantomCore;
+        while(!m_PendingInputs.empty() && m_PendingInputs.front().m_Tick <= m_PhantomTick + m_PhantomStep)
+        {
+            m_PhantomInput = m_PendingInputs.front().m_Input;
+            m_PendingInputs.pop_front();
+        }
+        CNetObj_PlayerInput Input = m_PhantomInput;
+        if(m_PhantomFreezeTime > 0)
+        {
+            Input.m_Direction = 0;
+            Input.m_Jump = 0;
+            Input.m_Hook = 0;
+            m_PhantomFreezeTime--;
+            if(m_PhantomFreezeTime == 0 && !m_PhantomCore.m_DeepFrozen)
+                m_PhantomCore.m_FreezeEnd = 0;
+        }
+        m_PhantomCore.m_Input = Input;
+        m_PhantomCore.Tick(true);
+        m_PhantomCore.Move();
+        int MapIndex = Collision()->GetMapIndex(m_PhantomCore.m_Pos);
+        if(HandlePhantomTiles(MapIndex))
+            return;
+        m_PhantomCore.Quantize();
+        m_PhantomTick += m_PhantomStep;
+        m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+        if(m_PhantomHistory.size() > 60)
+            m_PhantomHistory.pop_front();
+    }
+}
+
+void CFujixTas::CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick)
+{
+    CNetObj_CharacterCore CCore;
+    Core.Write(&CCore);
+    mem_zero(pChar, sizeof(*pChar));
+    pChar->m_X = CCore.m_X;
+    pChar->m_Y = CCore.m_Y;
+    pChar->m_VelX = CCore.m_VelX;
+    pChar->m_VelY = CCore.m_VelY;
+    pChar->m_Angle = CCore.m_Angle;
+    pChar->m_Direction = CCore.m_Direction;
+    pChar->m_Weapon = Core.m_ActiveWeapon;
+    pChar->m_HookState = CCore.m_HookState;
+    pChar->m_HookTick = CCore.m_HookTick;
+    pChar->m_HookX = CCore.m_HookX;
+    pChar->m_HookY = CCore.m_HookY;
+    pChar->m_HookDx = CCore.m_HookDx;
+    pChar->m_HookDy = CCore.m_HookDy;
+    pChar->m_HookedPlayer = CCore.m_HookedPlayer;
+    pChar->m_Jumped = CCore.m_Jumped;
+    pChar->m_Tick = Tick;
+    pChar->m_AttackTick = Core.m_HookTick + (Client()->GameTick(g_Config.m_ClDummy) - Tick);
+}
+
+void CFujixTas::OnUpdate()
+{
+    if(g_Config.m_ClFujixTasRecord && !m_Recording)
+        StartRecord();
+    else if(!g_Config.m_ClFujixTasRecord && m_Recording)
+        StopRecord();
+
+    if(g_Config.m_ClFujixTasPlay && !m_Playing)
+        StartPlay();
+    else if(!g_Config.m_ClFujixTasPlay && m_Playing)
+        StopPlay();
+
+    TickPhantom();
+}
+
+void CFujixTas::OnRender()
+{
+    if(!m_PhantomActive)
+        return;
+
+    CNetObj_Character Prev, Curr;
+    CoreToCharacter(m_PhantomPrevCore, &Prev, m_PhantomTick - m_PhantomStep);
+    CoreToCharacter(m_PhantomCore, &Curr, m_PhantomTick);
+
+    GameClient()->m_Players.RenderHook(&Prev, &Curr, &m_PhantomRenderInfo, -2);
+    GameClient()->m_Players.RenderHookCollLine(&Prev, &Curr, -2);
+    GameClient()->m_Players.RenderPlayer(&Prev, &Curr, &m_PhantomRenderInfo, -2);
 }
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -5,7 +5,10 @@
 #include <engine/storage.h>
 #include <engine/console.h>
 #include <game/generated/protocol.h>
+#include <game/gamecore.h>
+#include <game/client/render.h>
 #include <vector>
+#include <deque>
 
 class CFujixTas : public CComponent
 {
@@ -27,10 +30,49 @@ private:
     IOHANDLE m_File;
     std::vector<SEntry> m_vEntries;
     int m_PlayIndex;
+    int m_LastRecordTick;
+    CNetObj_PlayerInput m_CurrentInput;
+    bool m_StopPending;
+    int m_StopTick;
+
+    bool m_PhantomActive;
+    int m_PhantomTick;
+    CNetObj_PlayerInput m_PhantomInput;
+    struct SInputTick
+    {
+        int m_Tick;
+        CNetObj_PlayerInput m_Input;
+    };
+    std::deque<SInputTick> m_PendingInputs;
+    CCharacterCore m_PhantomCore;
+    CCharacterCore m_PhantomPrevCore;
+    CTeeRenderInfo m_PhantomRenderInfo;
+    int m_PhantomFreezeTime;
+    int m_PhantomStep;
+    int m_LastPredTick;
+
+    struct SPhantomState
+    {
+        int m_Tick;
+        CCharacterCore m_Core;
+        CCharacterCore m_PrevCore;
+        CNetObj_PlayerInput m_Input;
+        int m_FreezeTime;
+    };
+    std::deque<SPhantomState> m_PhantomHistory;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
     bool FetchEntry(CNetObj_PlayerInput *pInput);
+    void UpdatePlaybackInput();
+    void TickPhantom();
+    bool HandlePhantomTiles(int MapIndex);
+    void PhantomFreeze(int Seconds);
+    void PhantomUnfreeze();
+    void RollbackPhantom(int Ticks);
+    void RewriteFile();
+    void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
+    void FinishRecord();
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);
@@ -41,6 +83,8 @@ public:
 
     virtual void OnConsoleInit() override;
     virtual void OnMapLoad() override;
+    virtual void OnUpdate() override;
+    virtual void OnRender() override;
 
     void StartRecord();
     void StopRecord();
@@ -48,8 +92,11 @@ public:
     void StopPlay();
     bool IsRecording() const { return m_Recording; }
     bool IsPlaying() const { return m_Playing; }
+    bool IsPhantomActive() const { return m_PhantomActive; }
+    vec2 PhantomPos() const { return m_PhantomCore.m_Pos; }
     bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
     void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
+    void MaybeFinishRecord();
 };
 
 #endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3477,6 +3477,29 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
                Console()->ExecuteLine("fujix_record");
        if(DoButton_Menu(&s_PlayBtn, pPlayLabel, 0, &PlayButton))
                Console()->ExecuteLine("fujix_play");
+
+       CUIRect RewindBox, TicksBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RewindBox, &MainView);
+       static int s_RewindChk = 0;
+       if(DoButton_CheckBox(&s_RewindChk, Localize("Rollback on tiles"), g_Config.m_ClFujixTasRewind, &RewindBox))
+               g_Config.m_ClFujixTasRewind ^= 1;
+
+       if(g_Config.m_ClFujixTasRewind)
+       {
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &TicksBox, &MainView);
+               char aBuf[64];
+               str_format(aBuf, sizeof(aBuf), Localize("Rollback ticks: %d"), g_Config.m_ClFujixTasRewindTicks);
+               Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasRewindTicks, &g_Config.m_ClFujixTasRewindTicks, &TicksBox, aBuf, 5, 50);
+       }
+
+       CUIRect TpsBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &TpsBox, &MainView);
+       char aTpsBuf[64];
+       str_format(aTpsBuf, sizeof(aTpsBuf), Localize("Phantom tick rate: %d"), g_Config.m_ClFujixTasPhantomTps);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPhantomTps, &g_Config.m_ClFujixTasPhantomTps, &TpsBox, aTpsBuf, 1, 20);
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -9,7 +9,8 @@
 
 class CPlayers : public CComponent
 {
-	friend class CGhost;
+        friend class CGhost;
+        friend class CFujixTas;
 
 	void RenderHand6(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);
 	void RenderHand7(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -521,10 +521,38 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
                        return sizeof(TasInput);
                }
 
-               int Size = m_Controls.SnapInput(pData);
+               CNetObj_PlayerInput LocalInput;
+               int Size = m_Controls.SnapInput((int *)&LocalInput);
+               int Tick = Client()->PredGameTick(g_Config.m_ClDummy);
+
                if(Size > 0)
-                       m_FujixTas.RecordInput((const CNetObj_PlayerInput *)pData, Client()->PredGameTick(g_Config.m_ClDummy));
-               return Size;
+               {
+                     if(m_FujixTas.IsRecording())
+                     {
+                             m_FujixTas.RecordInput(&LocalInput, Tick);
+                             m_FujixTas.MaybeFinishRecord();
+                             CNetObj_PlayerInput NullInput;
+                             mem_zero(&NullInput, sizeof(NullInput));
+                             mem_copy(pData, &NullInput, sizeof(NullInput));
+                             return sizeof(NullInput);
+                     }
+
+                       m_FujixTas.RecordInput(&LocalInput, Tick);
+                       m_FujixTas.MaybeFinishRecord();
+                       mem_copy(pData, &LocalInput, sizeof(LocalInput));
+                       return Size;
+               }
+
+               if(m_FujixTas.IsRecording())
+               {
+                       CNetObj_PlayerInput NullInput;
+                       mem_zero(&NullInput, sizeof(NullInput));
+                       mem_copy(pData, &NullInput, sizeof(NullInput));
+                       m_FujixTas.MaybeFinishRecord();
+                       return sizeof(NullInput);
+               }
+
+               return 0;
        }
 	if(m_aLocalIds[!g_Config.m_ClDummy] < 0)
 	{
@@ -722,9 +750,12 @@ void CGameClient::OnReset()
 
 void CGameClient::UpdatePositions()
 {
-	// local character position
-	if(g_Config.m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
-	{
+       if(m_FujixTas.IsPhantomActive())
+       {
+               m_LocalCharacterPos = m_FujixTas.PhantomPos();
+       }
+       else if(g_Config.m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+       {
 		if(!AntiPingPlayers())
 		{
 			if(!m_Snap.m_pLocalCharacter || (m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER))
@@ -3480,8 +3511,8 @@ void CGameClient::UpdateRenderedCharacters()
 		}
 		m_Snap.m_aCharacters[i].m_Position = Pos;
 		m_aClients[i].m_RenderPos = Pos;
-		if(Predict() && i == m_Snap.m_LocalClientId)
-			m_LocalCharacterPos = Pos;
+               if(Predict() && i == m_Snap.m_LocalClientId && !m_FujixTas.IsPhantomActive())
+                       m_LocalCharacterPos = Pos;
 	}
 }
 


### PR DESCRIPTION
## Summary
- add phantom tick rate config and slider
- run phantom update in steps based on the tick rate setting

## Testing
- `python3 scripts/check_header_guards.py`
- `python3 scripts/check_unused_header_files.py`
- `python3 scripts/check_config_variables.py`
- `bash scripts/android/cmake_android.sh arm64 DDNet org.ddnet.client Debug build-android-arm64` *(fails: /root/Android/Sdk/ndk missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844d85eb7d0832c978cc5d6fc002f50