### PR TITLE
Refine input capture per tick

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -651,7 +651,10 @@ MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT 
 MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
 MACRO_CONFIG_INT(ClFujixTasRewind, cl_fujix_tas_rewind, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Rollback phantom on tiles")
 MACRO_CONFIG_INT(ClFujixTasRewindTicks, cl_fujix_tas_rewind_ticks, 10, 5, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to rollback phantom")
-MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 10, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Phantom ticks per second while recording")
+// Increased default and range to allow up to one phantom update per game tick
+// for improved accuracy when recording TAS runs. The previous default of 10 TPS
+// caused noticeable desync when using slow motion recording.
+MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 50, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Phantom ticks per second while recording")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -23,6 +23,7 @@ CFujixTas::CFujixTas()
     m_File = nullptr;
     m_PlayIndex = 0;
     m_LastRecordTick = -1;
+    mem_zero(&m_LastInput, sizeof(m_LastInput));
     m_aFilename[0] = '\0';
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
     m_StopPending = false;
@@ -47,9 +48,11 @@ void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
 {
     if(!m_Recording || !m_File)
         return;
-    SEntry e{Tick - m_StartTick, *pInput};
+    bool Active = mem_comp(pInput, &m_LastInput, sizeof(*pInput)) != 0;
+    SEntry e{Tick - m_StartTick, *pInput, Active};
     io_write(m_File, &e, sizeof(e));
     m_vEntries.push_back(e);
+    m_LastInput = *pInput;
 }
 
 
@@ -105,6 +108,7 @@ void CFujixTas::StartRecord()
     // the upcoming OnSnapInput call
     m_StartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_LastRecordTick = m_StartTick - 1;
+    mem_zero(&m_LastInput, sizeof(m_LastInput));
     m_Recording = true;
     g_Config.m_ClFujixTasRecord = 1;
     m_vEntries.clear();
@@ -120,6 +124,9 @@ void CFujixTas::StartRecord()
         m_PhantomRenderInfo = GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_RenderInfo;
     }
     m_PhantomTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    // Convert the configured tick rate into a simulation step. Higher values
+    // yield more precise phantom movement. With the new default of 50 TPS this
+    // results in a step of 1 game tick.
     m_PhantomStep = maximum(1, Client()->GameTickSpeed() / g_Config.m_ClFujixTasPhantomTps);
     m_LastPredTick = m_PhantomTick;
     mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
@@ -211,13 +218,12 @@ void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
         return;
     m_LastRecordTick = Tick;
 
+    bool StepTick = ((Tick - m_StartTick) % m_PhantomStep) == 0;
     if(m_Recording)
     {
-        if((Tick - m_StartTick) % m_PhantomStep == 0)
-        {
+        if(StepTick)
             m_PendingInputs.push_back({Tick, *pInput});
-            RecordEntry(pInput, Tick);
-        }
+        RecordEntry(pInput, Tick);
     }
     else
     {

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -20,6 +20,7 @@ private:
     {
         int m_Tick;
         CNetObj_PlayerInput m_Input;
+        bool m_Active; // true if any input changed this tick
     };
 
     bool m_Recording;
@@ -31,6 +32,7 @@ private:
     std::vector<SEntry> m_vEntries;
     int m_PlayIndex;
     int m_LastRecordTick;
+    CNetObj_PlayerInput m_LastInput;
     CNetObj_PlayerInput m_CurrentInput;
     bool m_StopPending;
     int m_StopTick;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3499,7 +3499,8 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
        MainView.HSplitTop(ms_ButtonHeight, &TpsBox, &MainView);
        char aTpsBuf[64];
        str_format(aTpsBuf, sizeof(aTpsBuf), Localize("Phantom tick rate: %d"), g_Config.m_ClFujixTasPhantomTps);
-       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPhantomTps, &g_Config.m_ClFujixTasPhantomTps, &TpsBox, aTpsBuf, 1, 20);
+       // Allow up to 50 TPS so the phantom can update every game tick if desired
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPhantomTps, &g_Config.m_ClFujixTasPhantomTps, &TpsBox, aTpsBuf, 1, 50);
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)


### PR DESCRIPTION
## Summary
- capture predicted input every game tick

## Testing
- `python3 scripts/fix_style.py`
- `cmake ..` *(fails: glslangValidator missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845f6e2a750832c9e3b93a0eff8e995