### PR TITLE
Improve input event recording

### DIFF
--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -1,106 +1,130 @@
 #ifndef GAME_CLIENT_COMPONENTS_FUJIX_TAS_H
 #define GAME_CLIENT_COMPONENTS_FUJIX_TAS_H
 
-#include <game/client/component.h>
-#include <engine/storage.h>
-#include <engine/console.h>
-#include <game/generated/protocol.h>
-#include <game/gamecore.h>
-#include <game/client/render.h>
-#include <vector>
 #include <deque>
+#include <engine/console.h>
+#include <engine/storage.h>
+#include <game/client/component.h>
+#include <game/client/render.h>
+#include <game/gamecore.h>
+#include <game/generated/protocol.h>
+#include <vector>
 
 class CFujixTas : public CComponent
 {
 public:
-    static const char *ms_pFujixDir;
+	static const char *ms_pFujixDir;
 
 private:
-    struct SEntry
-    {
-        int m_Tick;
-        CNetObj_PlayerInput m_Input;
-        bool m_Active; // true if any input changed this tick
-    };
+	struct SEntry
+	{
+		int m_Tick;
+		CNetObj_PlayerInput m_Input;
+		bool m_Active; // true if any input changed this tick
+	};
 
-    bool m_Recording;
-    bool m_Playing;
-    int m_StartTick;
-    int m_PlayStartTick;
-    char m_aFilename[IO_MAX_PATH_LENGTH];
-    IOHANDLE m_File;
-    std::vector<SEntry> m_vEntries;
-    int m_PlayIndex;
-    int m_LastRecordTick;
-    CNetObj_PlayerInput m_LastInput;
-    CNetObj_PlayerInput m_CurrentInput;
-    bool m_StopPending;
-    int m_StopTick;
+	bool m_Recording;
+	bool m_Playing;
+	int m_StartTick;
+	int m_PlayStartTick;
+	char m_aFilename[IO_MAX_PATH_LENGTH];
+	IOHANDLE m_File;
+	std::vector<SEntry> m_vEntries;
+	int m_PlayIndex;
+	int m_LastRecordTick;
+	CNetObj_PlayerInput m_LastInput;
+	CNetObj_PlayerInput m_CurrentInput;
+	bool m_StopPending;
+	int m_StopTick;
 
-    bool m_PhantomActive;
-    int m_PhantomTick;
-    CNetObj_PlayerInput m_PhantomInput;
-    struct SInputTick
-    {
-        int m_Tick;
-        CNetObj_PlayerInput m_Input;
-    };
-    std::deque<SInputTick> m_PendingInputs;
-    CCharacterCore m_PhantomCore;
-    CCharacterCore m_PhantomPrevCore;
-    CTeeRenderInfo m_PhantomRenderInfo;
-    int m_PhantomFreezeTime;
-    int m_PhantomStep;
-    int m_LastPredTick;
+	bool m_PhantomActive;
+	int m_PhantomTick;
+	CNetObj_PlayerInput m_PhantomInput;
+	struct SInputTick
+	{
+		int m_Tick;
+		CNetObj_PlayerInput m_Input;
+	};
+	std::deque<SInputTick> m_PendingInputs;
+	CCharacterCore m_PhantomCore;
+	CCharacterCore m_PhantomPrevCore;
+	CTeeRenderInfo m_PhantomRenderInfo;
+	int m_PhantomFreezeTime;
+	int m_PhantomStep;
+	int m_LastPredTick;
 
-    struct SPhantomState
-    {
-        int m_Tick;
-        CCharacterCore m_Core;
-        CCharacterCore m_PrevCore;
-        CNetObj_PlayerInput m_Input;
-        int m_FreezeTime;
-    };
-    std::deque<SPhantomState> m_PhantomHistory;
+	struct SPhantomState
+	{
+		int m_Tick;
+		CCharacterCore m_Core;
+		CCharacterCore m_PrevCore;
+		CNetObj_PlayerInput m_Input;
+		int m_FreezeTime;
+	};
+	std::deque<SPhantomState> m_PhantomHistory;
 
-    void GetPath(char *pBuf, int Size) const;
-    void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
-    bool FetchEntry(CNetObj_PlayerInput *pInput);
-    void UpdatePlaybackInput();
-    void TickPhantom();
-    void TickPhantomUpTo(int TargetTick);
-    void RenderFuturePath(int TicksAhead);
-    bool HandlePhantomTiles(int MapIndex);
-    void PhantomFreeze(int Seconds);
-    void PhantomUnfreeze();
-    void RollbackPhantom(int Ticks);
-    void RewriteFile();
-    void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
-    void FinishRecord();
+       enum
+       {
+               ACTION_HOOK = 0,
+               ACTION_MOVE_LEFT = 1,
+               ACTION_MOVE_RIGHT = 2,
+               ACTION_JUMP = 3,
+               ACTION_HOOK_ATTACH = 4,
+               ACTION_HOOK_DETACH = 5,
+       };
 
-    static void ConRecord(IConsole::IResult *pResult, void *pUserData);
-    static void ConPlay(IConsole::IResult *pResult, void *pUserData);
+       struct SInputEvent
+       {
+               int m_Tick;
+               vec2 m_Pos;
+               int m_Action;
+               bool m_Pressed;
+       };
+       IOHANDLE m_EventFile;
+       std::vector<SInputEvent> m_vEvents;
+       int m_EventIndex;
+       int m_LastHookState;
+
+	void GetPath(char *pBuf, int Size) const;
+	void GetEventPath(char *pBuf, int Size) const;
+	void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
+	bool FetchEntry(CNetObj_PlayerInput *pInput);
+	void UpdatePlaybackInput();
+	void TickPhantom();
+	void TickPhantomUpTo(int TargetTick);
+	void RenderFuturePath(int TicksAhead);
+	bool HandlePhantomTiles(int MapIndex);
+	void PhantomFreeze(int Seconds);
+	void PhantomUnfreeze();
+	void RollbackPhantom(int Ticks);
+	void RewriteFile();
+	void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
+	void FinishRecord();
+
+	static void ConRecord(IConsole::IResult *pResult, void *pUserData);
+	static void ConPlay(IConsole::IResult *pResult, void *pUserData);
 
 public:
-    CFujixTas();
-    virtual int Sizeof() const override { return sizeof(*this); }
+	CFujixTas();
+	virtual int Sizeof() const override { return sizeof(*this); }
 
-    virtual void OnConsoleInit() override;
-    virtual void OnMapLoad() override;
-    virtual void OnUpdate() override;
-    virtual void OnRender() override;
+	virtual void OnConsoleInit() override;
+	virtual void OnMapLoad() override;
+	virtual void OnUpdate() override;
+	virtual void OnRender() override;
 
-    void StartRecord();
-    void StopRecord();
-    void StartPlay();
-    void StopPlay();
-    bool IsRecording() const { return m_Recording; }
-    bool IsPlaying() const { return m_Playing; }
-    bool IsPhantomActive() const { return m_PhantomActive; }
-    vec2 PhantomPos() const { return m_PhantomCore.m_Pos; }
-    bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
-    void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
-    void MaybeFinishRecord();
+	void StartRecord();
+	void StopRecord();
+	void StartPlay();
+	void StopPlay();
+	bool IsRecording() const { return m_Recording; }
+	bool IsPlaying() const { return m_Playing; }
+	bool IsPhantomActive() const { return m_PhantomActive; }
+	vec2 PhantomPos() const { return m_PhantomCore.m_Pos; }
+	bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
+	void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
+	void RecordEvent(int Tick, vec2 Pos, int Action, bool Pressed);
+	void MaybeFinishRecord();
 };
 
 #endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H


### PR DESCRIPTION
## Summary
- capture start and end positions for movement and hook
- record hook attach/detach and jump press events
- playback supports new action types

## Testing
- `cargo test --locked` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684650826f88832c9680127a3421b491