### PR TITLE
Improve input event recording

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -658,6 +658,8 @@ MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 50, 1, 50, CFGF
 // Number of future ticks to visualize while playing TAS. Allows estimating the
 // upcoming path of the phantom on the HUD.
 MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks of phantom path preview")
+MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
+MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -36,12 +36,23 @@ CFujixTas::CFujixTas()
     m_LastPredTick = 0;
     m_PhantomHistory.clear();
     m_PendingInputs.clear();
+    m_OldShowOthers = g_Config.m_ClShowOthers;
+    m_HookEventIndex = 0;
+    m_HookEventFile = nullptr;
+    m_vHookEvents.clear();
+    m_LastHookState = HOOK_RETRACTED;
 }
 
 void CFujixTas::GetPath(char *pBuf, int Size) const
 {
     const char *pMap = Client()->GetCurrentMap();
     str_format(pBuf, Size, "%s/%s.fjx", ms_pFujixDir, pMap);
+}
+
+void CFujixTas::GetHookEventPath(char *pBuf, int Size) const
+{
+    const char *pMap = Client()->GetCurrentMap();
+    str_format(pBuf, Size, "%s/%s_hook.fjx", ms_pFujixDir, pMap);
 }
 
 void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
@@ -84,6 +95,20 @@ void CFujixTas::UpdatePlaybackInput()
         m_PlayIndex++;
     }
 
+    const int TickGrace = 1;
+    while(m_HookEventIndex < (int)m_vHookEvents.size())
+    {
+        const SHookEvent &Ev = m_vHookEvents[m_HookEventIndex];
+        int EventTick = m_PlayStartTick + Ev.m_Tick;
+        bool TickReached = PredTick >= EventTick;
+        bool PosReached = distance(GameClient()->m_PredictedChar.m_Pos, Ev.m_Pos) < 1.0f;
+        bool DoApply = Ev.m_Pressed ? TickReached : (TickReached || PosReached || PredTick >= EventTick + TickGrace);
+        if(!DoApply)
+            break;
+        m_CurrentInput.m_Hook = Ev.m_Pressed ? 1 : 0;
+        m_HookEventIndex++;
+    }
+
     if(m_PlayIndex >= (int)m_vEntries.size() &&
        PredTick >= m_PlayStartTick + m_vEntries.back().m_Tick)
     {
@@ -99,9 +124,18 @@ void CFujixTas::StartRecord()
     GetPath(m_aFilename, sizeof(m_aFilename));
     Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
     m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
-    if(!m_File)
+    char aHookPath[IO_MAX_PATH_LENGTH];
+    GetHookEventPath(aHookPath, sizeof(aHookPath));
+    m_HookEventFile = Storage()->OpenFile(aHookPath, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    if(!m_File || !m_HookEventFile)
     {
         Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for recording");
+        if(m_File)
+            io_close(m_File);
+        if(m_HookEventFile)
+            io_close(m_HookEventFile);
+        m_File = nullptr;
+        m_HookEventFile = nullptr;
         return;
     }
     // start recording on the next predicted tick to align with
@@ -132,7 +166,13 @@ void CFujixTas::StartRecord()
     mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
     m_PhantomFreezeTime = 0;
     m_PhantomActive = true;
+    m_PhantomCore.m_HookHitDisabled = true;
+    m_PhantomCore.m_CollisionDisabled = true;
     m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+
+    m_OldShowOthers = g_Config.m_ClShowOthersAlpha;
+    if(!g_Config.m_ClFujixTasShowPlayers)
+        g_Config.m_ClShowOthersAlpha = 0;
 }
 
 void CFujixTas::FinishRecord()
@@ -141,7 +181,10 @@ void CFujixTas::FinishRecord()
         return;
     if(m_File)
         io_close(m_File);
+    if(m_HookEventFile)
+        io_close(m_HookEventFile);
     m_File = nullptr;
+    m_HookEventFile = nullptr;
     m_Recording = false;
     g_Config.m_ClFujixTasRecord = 0;
     m_PhantomActive = false;
@@ -149,6 +192,9 @@ void CFujixTas::FinishRecord()
     m_LastRecordTick = -1;
     m_StopPending = false;
     m_StopTick = -1;
+    m_HookEventIndex = 0;
+    m_vHookEvents.clear();
+    g_Config.m_ClShowOthersAlpha = m_OldShowOthers;
 }
 
 void CFujixTas::StopRecord()
@@ -179,11 +225,25 @@ void CFujixTas::StartPlay()
         return;
     }
 
+    char aHookPath[IO_MAX_PATH_LENGTH];
+    GetHookEventPath(aHookPath, sizeof(aHookPath));
+    IOHANDLE HookFile = Storage()->OpenFile(aHookPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+
     m_vEntries.clear();
     SEntry e;
     while(io_read(File, &e, sizeof(e)) == sizeof(e))
         m_vEntries.push_back(e);
     io_close(File);
+
+    m_vHookEvents.clear();
+    if(HookFile)
+    {
+        SHookEvent Ev;
+        while(io_read(HookFile, &Ev, sizeof(Ev)) == sizeof(Ev))
+            m_vHookEvents.push_back(Ev);
+        io_close(HookFile);
+    }
+    m_HookEventIndex = 0;
 
     m_PlayIndex = 0;
     // similar to recording, start playback on the next tick so the
@@ -205,6 +265,8 @@ void CFujixTas::StopPlay()
     m_PlayIndex = 0;
     m_PlayStartTick = 0;
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
+    m_vHookEvents.clear();
+    m_HookEventIndex = 0;
 }
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
@@ -217,6 +279,12 @@ void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
     if(Tick == m_LastRecordTick)
         return;
     m_LastRecordTick = Tick;
+
+    if(pInput->m_Hook != m_LastInput.m_Hook)
+    {
+        vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+        RecordHookEvent(Tick, Pos, pInput->m_Hook != 0);
+    }
 
     RecordEntry(pInput, Tick);
 
@@ -264,6 +332,15 @@ void CFujixTas::RewriteFile()
     m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
     for(const auto &e : m_vEntries)
         io_write(m_File, &e, sizeof(e));
+}
+
+void CFujixTas::RecordHookEvent(int Tick, vec2 Pos, bool Pressed)
+{
+    if(!m_HookEventFile)
+        return;
+    SHookEvent Ev{Tick - m_StartTick, Pos, Pressed};
+    io_write(m_HookEventFile, &Ev, sizeof(Ev));
+    m_vHookEvents.push_back(Ev);
 }
 
 void CFujixTas::RollbackPhantom(int Ticks)
@@ -506,6 +583,7 @@ void CFujixTas::OnRender()
     GameClient()->m_Players.RenderPlayer(&Prev, &Curr, &m_PhantomRenderInfo, -2);
 
     RenderFuturePath(g_Config.m_ClFujixTasPreviewTicks);
+    RenderRecommendedRoute(g_Config.m_ClFujixTasRouteTicks);
 }
 
 void CFujixTas::RenderFuturePath(int TicksAhead)
@@ -537,5 +615,40 @@ void CFujixTas::RenderFuturePath(int TicksAhead)
         Graphics()->LinesDraw(&Line, 1);
     }
     Graphics()->LinesEnd();
+}
+
+void CFujixTas::RenderRecommendedRoute(int TicksAhead)
+{
+    if(TicksAhead <= 0 || !m_PhantomActive)
+        return;
+
+    CFujixTas Tmp = *this;
+    Graphics()->TextureClear();
+    Graphics()->LinesBegin();
+    Graphics()->SetColor(0.0f, 1.0f, 0.0f, 1.0f);
+
+    vec2 Prev = Tmp.m_PhantomCore.m_Pos;
+    int TargetTick = m_PhantomTick + TicksAhead;
+    while(Tmp.m_PhantomTick < TargetTick)
+    {
+        int StepTarget = minimum(TargetTick, Tmp.m_PhantomTick + Tmp.m_PhantomStep);
+        Tmp.TickPhantomUpTo(StepTarget);
+        vec2 Pos = Tmp.m_PhantomCore.m_Pos;
+        IGraphics::CLineItem Line(Prev.x, Prev.y, Pos.x, Pos.y);
+        Graphics()->LinesDraw(&Line, 1);
+
+        if(Tmp.m_PhantomInput.m_Hook)
+        {
+            Graphics()->QuadsBegin();
+            IGraphics::CQuadItem Quad(Pos.x - 2.0f, Pos.y - 2.0f, 4.0f, 4.0f);
+            Graphics()->QuadsDraw(&Quad, 1);
+            Graphics()->QuadsEnd();
+        }
+
+        Prev = Pos;
+    }
+
+    Graphics()->LinesEnd();
+    Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 }
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -53,6 +53,8 @@ private:
     int m_PhantomStep;
     int m_LastPredTick;
 
+    int m_OldShowOthers;
+
     struct SPhantomState
     {
         int m_Tick;
@@ -62,6 +64,17 @@ private:
         int m_FreezeTime;
     };
     std::deque<SPhantomState> m_PhantomHistory;
+
+    struct SHookEvent
+    {
+        int m_Tick;
+        vec2 m_Pos;
+        bool m_Pressed;
+    };
+    std::vector<SHookEvent> m_vHookEvents;
+    int m_HookEventIndex;
+    IOHANDLE m_HookEventFile;
+    int m_LastHookState;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
@@ -77,6 +90,9 @@ private:
     void RewriteFile();
     void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
     void FinishRecord();
+    void RecordHookEvent(int Tick, vec2 Pos, bool Pressed);
+    void GetHookEventPath(char *pBuf, int Size) const;
+    void RenderRecommendedRoute(int TicksAhead);
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3508,6 +3508,20 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
        char aPreviewBuf[64];
        str_format(aPreviewBuf, sizeof(aPreviewBuf), Localize("Preview ticks: %d"), g_Config.m_ClFujixTasPreviewTicks);
        Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPreviewTicks, &g_Config.m_ClFujixTasPreviewTicks, &PreviewBox, aPreviewBuf, 0, 200);
+
+       CUIRect ShowPlayersBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &ShowPlayersBox, &MainView);
+       static int s_ShowPlayersChk = 0;
+       if(DoButton_CheckBox(&s_ShowPlayersChk, Localize("Show players"), g_Config.m_ClFujixTasShowPlayers, &ShowPlayersBox))
+               g_Config.m_ClFujixTasShowPlayers ^= 1;
+
+       CUIRect RouteBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RouteBox, &MainView);
+       char aRouteBuf[64];
+       str_format(aRouteBuf, sizeof(aRouteBuf), Localize("Route ticks: %d"), g_Config.m_ClFujixTasRouteTicks);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasRouteTicks, &g_Config.m_ClFujixTasRouteTicks, &RouteBox, aRouteBuf, 0, 200);
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)


### PR DESCRIPTION
## Summary
- capture start and end positions for hook presses to improve playback accuracy
- phantom can't hook or collide with other players during recording
- add settings to hide players while recording and to show a recommended green route ahead
- maintain preview and route ticks with new config options

## Testing
- `cargo test --locked` *(fails: environment variable `DDNET_TEST_LIBRARIES` not set)*

------
https://chatgpt.com/codex/tasks/task_e_684650826f88832c9680127a3421b491