### PR TITLE
Improve input event recording

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -658,6 +658,8 @@ MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 50, 1, 50, CFGF
 // Number of future ticks to visualize while playing TAS. Allows estimating the
 // upcoming path of the phantom on the HUD.
 MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks of phantom path preview")
+MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
+MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -53,6 +53,8 @@ private:
     int m_PhantomStep;
     int m_LastPredTick;
 
+    int m_OldShowOthers;
+
     struct SPhantomState
     {
         int m_Tick;
@@ -62,6 +64,17 @@ private:
         int m_FreezeTime;
     };
     std::deque<SPhantomState> m_PhantomHistory;
+
+    struct SHookEvent
+    {
+        int m_Tick;
+        vec2 m_Pos;
+        bool m_Pressed;
+    };
+    std::vector<SHookEvent> m_vHookEvents;
+    int m_HookEventIndex;
+    IOHANDLE m_HookEventFile;
+    int m_LastHookState;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
@@ -77,6 +90,9 @@ private:
     void RewriteFile();
     void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
     void FinishRecord();
+    void RecordHookEvent(int Tick, vec2 Pos, bool Pressed);
+    void GetHookEventPath(char *pBuf, int Size) const;
+    void RenderRecommendedRoute(int TicksAhead);
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3508,6 +3508,20 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
        char aPreviewBuf[64];
        str_format(aPreviewBuf, sizeof(aPreviewBuf), Localize("Preview ticks: %d"), g_Config.m_ClFujixTasPreviewTicks);
        Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPreviewTicks, &g_Config.m_ClFujixTasPreviewTicks, &PreviewBox, aPreviewBuf, 0, 200);
+
+       CUIRect ShowPlayersBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &ShowPlayersBox, &MainView);
+       static int s_ShowPlayersChk = 0;
+       if(DoButton_CheckBox(&s_ShowPlayersChk, Localize("Show players"), g_Config.m_ClFujixTasShowPlayers, &ShowPlayersBox))
+               g_Config.m_ClFujixTasShowPlayers ^= 1;
+
+       CUIRect RouteBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RouteBox, &MainView);
+       char aRouteBuf[64];
+       str_format(aRouteBuf, sizeof(aRouteBuf), Localize("Route ticks: %d"), g_Config.m_ClFujixTasRouteTicks);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasRouteTicks, &g_Config.m_ClFujixTasRouteTicks, &RouteBox, aRouteBuf, 0, 200);
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)


### PR DESCRIPTION
## Summary
- capture start and end positions for hook presses to improve playback accuracy
- phantom can't hook or collide with other players during recording
- add settings to hide players while recording and to show a recommended green route ahead
- maintain preview and route ticks with new config options
- fix recommended route rendering by drawing hook markers after line path

## Testing
- `cargo test --locked` *(fails: environment variable `DDNET_TEST_LIBRARIES` not set)*

------
https://chatgpt.com/codex/tasks/task_e_684650826f88832c9680127a3421b491