### PR TITLE
Add phantom test playback

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -649,6 +649,7 @@ MACRO_CONFIG_INT(ClRotationSpeed, cl_rotation_speed, 40, 1, 120, CFGFLAG_CLIENT 
 MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 40, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera speed")
 MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Record FUJIX TAS")
 MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
+MACRO_CONFIG_INT(ClFujixTasTest, cl_fujix_tas_test, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS as phantom")
 MACRO_CONFIG_INT(ClFujixTasRewind, cl_fujix_tas_rewind, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Rollback phantom on tiles")
 MACRO_CONFIG_INT(ClFujixTasRewindTicks, cl_fujix_tas_rewind_ticks, 10, 5, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to rollback phantom")
 // Increased default and range to allow up to one phantom update per game tick
@@ -658,6 +659,8 @@ MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 50, 1, 50, CFGF
 // Number of future ticks to visualize while playing TAS. Allows estimating the
 // upcoming path of the phantom on the HUD.
 MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks of phantom path preview")
+MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
+MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -25,7 +25,9 @@ private:
 
     bool m_Recording;
     bool m_Playing;
+    bool m_Testing;
     int m_StartTick;
+    int m_TestStartTick;
     int m_PlayStartTick;
     char m_aFilename[IO_MAX_PATH_LENGTH];
     IOHANDLE m_File;
@@ -53,6 +55,8 @@ private:
     int m_PhantomStep;
     int m_LastPredTick;
 
+    int m_OldShowOthers;
+
     struct SPhantomState
     {
         int m_Tick;
@@ -62,6 +66,26 @@ private:
         int m_FreezeTime;
     };
     std::deque<SPhantomState> m_PhantomHistory;
+
+    enum EEventType
+    {
+        EVENT_HOOK,
+        EVENT_LEFT,
+        EVENT_RIGHT,
+        EVENT_JUMP
+    };
+
+    struct SEvent
+    {
+        int m_Tick;
+        vec2 m_Pos;
+        EEventType m_Type;
+        bool m_Pressed; // for jump only pressed=true is used
+    };
+
+    std::vector<SEvent> m_vEvents;
+    int m_EventIndex;
+    IOHANDLE m_EventFile;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
@@ -77,9 +101,13 @@ private:
     void RewriteFile();
     void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
     void FinishRecord();
+    void RecordEvent(int Tick, vec2 Pos, EEventType Type, bool Pressed);
+    void GetEventPath(char *pBuf, int Size) const;
+    void RenderRecommendedRoute(int TicksAhead);
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);
+    static void ConTest(IConsole::IResult *pResult, void *pUserData);
 
 public:
     CFujixTas();
@@ -94,8 +122,11 @@ public:
     void StopRecord();
     void StartPlay();
     void StopPlay();
+    void StartTest();
+    void StopTest();
     bool IsRecording() const { return m_Recording; }
     bool IsPlaying() const { return m_Playing; }
+    bool IsTesting() const { return m_Testing; }
     bool IsPhantomActive() const { return m_PhantomActive; }
     vec2 PhantomPos() const { return m_PhantomCore.m_Pos; }
     bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3463,20 +3463,25 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 void CMenus::RenderSettingsFujix(CUIRect MainView)
 {
-       CUIRect RecordButton, PlayButton;
+       CUIRect RecordButton, PlayButton, TestButton;
        MainView.HSplitTop(10.0f, nullptr, &MainView);
        MainView.HSplitTop(ms_ButtonHeight, &RecordButton, &MainView);
        MainView.HSplitTop(5.0f, nullptr, &MainView);
        MainView.HSplitTop(ms_ButtonHeight, &PlayButton, &MainView);
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &TestButton, &MainView);
 
-       static CButtonContainer s_RecordBtn, s_PlayBtn;
+       static CButtonContainer s_RecordBtn, s_PlayBtn, s_TestBtn;
        const char *pRecLabel = GameClient()->m_FujixTas.IsRecording() ? Localize("Stop") : Localize("Record");
        const char *pPlayLabel = GameClient()->m_FujixTas.IsPlaying() ? Localize("Stop") : Localize("Play");
+       const char *pTestLabel = GameClient()->m_FujixTas.IsTesting() ? Localize("Stop") : Localize("Play (test)");
 
        if(DoButton_Menu(&s_RecordBtn, pRecLabel, 0, &RecordButton))
                Console()->ExecuteLine("fujix_record");
        if(DoButton_Menu(&s_PlayBtn, pPlayLabel, 0, &PlayButton))
                Console()->ExecuteLine("fujix_play");
+       if(DoButton_Menu(&s_TestBtn, pTestLabel, 0, &TestButton))
+               Console()->ExecuteLine("fujix_test");
 
        CUIRect RewindBox, TicksBox;
        MainView.HSplitTop(5.0f, nullptr, &MainView);
@@ -3508,6 +3513,20 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
        char aPreviewBuf[64];
        str_format(aPreviewBuf, sizeof(aPreviewBuf), Localize("Preview ticks: %d"), g_Config.m_ClFujixTasPreviewTicks);
        Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPreviewTicks, &g_Config.m_ClFujixTasPreviewTicks, &PreviewBox, aPreviewBuf, 0, 200);
+
+       CUIRect ShowPlayersBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &ShowPlayersBox, &MainView);
+       static int s_ShowPlayersChk = 0;
+       if(DoButton_CheckBox(&s_ShowPlayersChk, Localize("Show players"), g_Config.m_ClFujixTasShowPlayers, &ShowPlayersBox))
+               g_Config.m_ClFujixTasShowPlayers ^= 1;
+
+       CUIRect RouteBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RouteBox, &MainView);
+       char aRouteBuf[64];
+       str_format(aRouteBuf, sizeof(aRouteBuf), Localize("Route ticks: %d"), g_Config.m_ClFujixTasRouteTicks);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasRouteTicks, &g_Config.m_ClFujixTasRouteTicks, &RouteBox, aRouteBuf, 0, 200);
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)


### PR DESCRIPTION
## Summary
- add `cl_fujix_tas_test` option
- implement StartTest/StopTest with console command `fujix_test`
- update phantom ticks to apply recorded hook events during test playback
- show new "Play (test)" button in Fujix settings
- refine event recording by storing position-based actions for hook, movement, and jump

## Testing
- `cargo test --locked` *(fails: environment variable `DDNET_TEST_LIBRARIES` required but not found)*

------
https://chatgpt.com/codex/tasks/task_e_684650826f88832c9680127a3421b491