### PR TITLE
Improve hook direction handling

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -649,6 +649,7 @@ MACRO_CONFIG_INT(ClRotationSpeed, cl_rotation_speed, 40, 1, 120, CFGFLAG_CLIENT 
 MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 40, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera speed")
 MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Record FUJIX TAS")
 MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
+MACRO_CONFIG_INT(ClFujixTasTest, cl_fujix_tas_test, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS as phantom")
 MACRO_CONFIG_INT(ClFujixTasRewind, cl_fujix_tas_rewind, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Rollback phantom on tiles")
 MACRO_CONFIG_INT(ClFujixTasRewindTicks, cl_fujix_tas_rewind_ticks, 10, 5, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to rollback phantom")
 // Increased default and range to allow up to one phantom update per game tick
@@ -658,6 +659,9 @@ MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 50, 1, 50, CFGF
 // Number of future ticks to visualize while playing TAS. Allows estimating the
 // upcoming path of the phantom on the HUD.
 MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks of phantom path preview")
+MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
+MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
+MACRO_CONFIG_INT(ClFujixTasDebug, cl_fujix_tas_debug, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable TAS debug output")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -11,6 +11,7 @@
 #include <game/gamecore.h>
 #include <game/client/components/players.h>
 #include <base/system.h>
+#include <cmath>
 
 const char *CFujixTas::ms_pFujixDir = "fujix";
 
@@ -18,12 +19,15 @@ CFujixTas::CFujixTas()
 {
     m_Recording = false;
     m_Playing = false;
+    m_Testing = false;
     m_StartTick = 0;
+    m_TestStartTick = 0;
     m_PlayStartTick = 0;
     m_File = nullptr;
     m_PlayIndex = 0;
     m_LastRecordTick = -1;
     mem_zero(&m_LastInput, sizeof(m_LastInput));
+    m_LastHookState = HOOK_IDLE;
     m_aFilename[0] = '\0';
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
     m_StopPending = false;
@@ -36,12 +40,22 @@ CFujixTas::CFujixTas()
     m_LastPredTick = 0;
     m_PhantomHistory.clear();
     m_PendingInputs.clear();
+    m_OldShowOthers = g_Config.m_ClShowOthersAlpha;
+    m_EventIndex = 0;
+    m_EventFile = nullptr;
+    m_vEvents.clear();
 }
 
 void CFujixTas::GetPath(char *pBuf, int Size) const
 {
     const char *pMap = Client()->GetCurrentMap();
     str_format(pBuf, Size, "%s/%s.fjx", ms_pFujixDir, pMap);
+}
+
+void CFujixTas::GetEventPath(char *pBuf, int Size) const
+{
+    const char *pMap = Client()->GetCurrentMap();
+    str_format(pBuf, Size, "%s/%s_events.fjx", ms_pFujixDir, pMap);
 }
 
 void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
@@ -84,6 +98,58 @@ void CFujixTas::UpdatePlaybackInput()
         m_PlayIndex++;
     }
 
+    while(m_EventIndex < (int)m_vEvents.size() &&
+          m_PlayStartTick + m_vEvents[m_EventIndex].m_Tick <= PredTick)
+    {
+        const SEvent &Ev = m_vEvents[m_EventIndex];
+        switch(Ev.m_Type)
+        {
+        case EVENT_HOOK:
+            m_CurrentInput.m_Hook = Ev.m_Pressed ? 1 : 0;
+            break;
+        case EVENT_HOOK_ATTACH:
+            m_CurrentInput.m_Hook = 1;
+            break;
+        case EVENT_HOOK_DETACH:
+            m_CurrentInput.m_Hook = 0;
+            break;
+        case EVENT_HOOK_TARGET:
+        {
+            if(Ev.m_Pressed)
+            {
+                vec2 PlayerPos = GameClient()->m_PredictedChar.m_Pos;
+                vec2 Dir = Ev.m_Pos - PlayerPos;
+                if(length(Dir) > 0.0f)
+                {
+                    Dir = normalize(Dir);
+                    m_CurrentInput.m_TargetX = (int)(Dir.x * 256.0f);
+                    m_CurrentInput.m_TargetY = (int)(Dir.y * 256.0f);
+                }
+            }
+            break;
+        }
+        case EVENT_LEFT:
+            if(Ev.m_Pressed)
+                m_CurrentInput.m_Direction = -1;
+            else if(m_CurrentInput.m_Direction == -1)
+                m_CurrentInput.m_Direction = 0;
+            break;
+        case EVENT_RIGHT:
+            if(Ev.m_Pressed)
+                m_CurrentInput.m_Direction = 1;
+            else if(m_CurrentInput.m_Direction == 1)
+                m_CurrentInput.m_Direction = 0;
+            break;
+        case EVENT_JUMP:
+            if(Ev.m_Pressed)
+                m_CurrentInput.m_Jump |= 1;
+            else
+                m_CurrentInput.m_Jump &= ~1;
+            break;
+        }
+        m_EventIndex++;
+    }
+
     if(m_PlayIndex >= (int)m_vEntries.size() &&
        PredTick >= m_PlayStartTick + m_vEntries.back().m_Tick)
     {
@@ -99,9 +165,18 @@ void CFujixTas::StartRecord()
     GetPath(m_aFilename, sizeof(m_aFilename));
     Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
     m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
-    if(!m_File)
+    char aEventPath[IO_MAX_PATH_LENGTH];
+    GetEventPath(aEventPath, sizeof(aEventPath));
+    m_EventFile = Storage()->OpenFile(aEventPath, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    if(!m_File || !m_EventFile)
     {
         Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for recording");
+        if(m_File)
+            io_close(m_File);
+        if(m_EventFile)
+            io_close(m_EventFile);
+        m_File = nullptr;
+        m_EventFile = nullptr;
         return;
     }
     // start recording on the next predicted tick to align with
@@ -109,6 +184,7 @@ void CFujixTas::StartRecord()
     m_StartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_LastRecordTick = m_StartTick - 1;
     mem_zero(&m_LastInput, sizeof(m_LastInput));
+    m_LastHookState = GameClient()->m_PredictedChar.m_HookState;
     m_Recording = true;
     g_Config.m_ClFujixTasRecord = 1;
     m_vEntries.clear();
@@ -132,7 +208,13 @@ void CFujixTas::StartRecord()
     mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
     m_PhantomFreezeTime = 0;
     m_PhantomActive = true;
+    m_PhantomCore.m_HookHitDisabled = true;
+    m_PhantomCore.m_CollisionDisabled = true;
     m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+
+    m_OldShowOthers = g_Config.m_ClShowOthersAlpha;
+    if(!g_Config.m_ClFujixTasShowPlayers)
+        g_Config.m_ClShowOthersAlpha = 0;
 }
 
 void CFujixTas::FinishRecord()
@@ -141,7 +223,10 @@ void CFujixTas::FinishRecord()
         return;
     if(m_File)
         io_close(m_File);
+    if(m_EventFile)
+        io_close(m_EventFile);
     m_File = nullptr;
+    m_EventFile = nullptr;
     m_Recording = false;
     g_Config.m_ClFujixTasRecord = 0;
     m_PhantomActive = false;
@@ -149,6 +234,9 @@ void CFujixTas::FinishRecord()
     m_LastRecordTick = -1;
     m_StopPending = false;
     m_StopTick = -1;
+    m_EventIndex = 0;
+    m_vEvents.clear();
+    g_Config.m_ClShowOthersAlpha = m_OldShowOthers;
 }
 
 void CFujixTas::StopRecord()
@@ -179,11 +267,25 @@ void CFujixTas::StartPlay()
         return;
     }
 
+    char aEventPath[IO_MAX_PATH_LENGTH];
+    GetEventPath(aEventPath, sizeof(aEventPath));
+    IOHANDLE EventFile = Storage()->OpenFile(aEventPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+
     m_vEntries.clear();
     SEntry e;
     while(io_read(File, &e, sizeof(e)) == sizeof(e))
         m_vEntries.push_back(e);
     io_close(File);
+
+    m_vEvents.clear();
+    if(EventFile)
+    {
+        SEvent Ev;
+        while(io_read(EventFile, &Ev, sizeof(Ev)) == sizeof(Ev))
+            m_vEvents.push_back(Ev);
+        io_close(EventFile);
+    }
+    m_EventIndex = 0;
 
     m_PlayIndex = 0;
     // similar to recording, start playback on the next tick so the
@@ -205,6 +307,83 @@ void CFujixTas::StopPlay()
     m_PlayIndex = 0;
     m_PlayStartTick = 0;
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
+    m_vEvents.clear();
+    m_EventIndex = 0;
+}
+
+void CFujixTas::StartTest()
+{
+    if(m_Testing)
+        StopTest();
+
+    char aPath[IO_MAX_PATH_LENGTH];
+    GetPath(aPath, sizeof(aPath));
+    IOHANDLE File = Storage()->OpenFile(aPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    if(!File)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for test");
+        return;
+    }
+
+    char aEventPath[IO_MAX_PATH_LENGTH];
+    GetEventPath(aEventPath, sizeof(aEventPath));
+    IOHANDLE EventFile = Storage()->OpenFile(aEventPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+
+    m_vEntries.clear();
+    SEntry e;
+    while(io_read(File, &e, sizeof(e)) == sizeof(e))
+        m_vEntries.push_back(e);
+    io_close(File);
+
+    m_vEvents.clear();
+    if(EventFile)
+    {
+        SEvent Ev;
+        while(io_read(EventFile, &Ev, sizeof(Ev)) == sizeof(Ev))
+            m_vEvents.push_back(Ev);
+        io_close(EventFile);
+    }
+    m_EventIndex = 0;
+
+    // init phantom at current position
+    if(GameClient()->m_Snap.m_LocalClientId >= 0)
+    {
+        m_PhantomCore = GameClient()->m_PredictedChar;
+        m_PhantomPrevCore = m_PhantomCore;
+        m_PhantomCore.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        m_PhantomRenderInfo = GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_RenderInfo;
+    }
+    m_PhantomTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_PhantomStep = maximum(1, Client()->GameTickSpeed() / g_Config.m_ClFujixTasPhantomTps);
+    m_LastPredTick = m_PhantomTick;
+    mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
+    m_PhantomFreezeTime = 0;
+    m_PhantomActive = true;
+    m_PhantomCore.m_HookHitDisabled = true;
+    m_PhantomCore.m_CollisionDisabled = true;
+    m_PhantomHistory.clear();
+    m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+
+    m_PendingInputs.clear();
+    m_TestStartTick = m_PhantomTick + 1;
+    for(const auto &Entry : m_vEntries)
+        m_PendingInputs.push_back({m_TestStartTick + Entry.m_Tick, Entry.m_Input});
+
+    m_Testing = !m_vEntries.empty();
+    if(m_Testing)
+        g_Config.m_ClFujixTasTest = 1;
+}
+
+void CFujixTas::StopTest()
+{
+    m_Testing = false;
+    g_Config.m_ClFujixTasTest = 0;
+    m_PhantomActive = false;
+    m_PendingInputs.clear();
+    m_PhantomHistory.clear();
+    m_vEntries.clear();
+    m_vEvents.clear();
+    m_EventIndex = 0;
 }
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
@@ -217,6 +396,43 @@ void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
     if(Tick == m_LastRecordTick)
         return;
     m_LastRecordTick = Tick;
+
+    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+
+    if(m_LastInput.m_Direction != pInput->m_Direction)
+    {
+        if(m_LastInput.m_Direction != 0)
+            RecordEvent(Tick, Pos, m_LastInput.m_Direction < 0 ? EVENT_LEFT : EVENT_RIGHT, false);
+        if(pInput->m_Direction != 0)
+            RecordEvent(Tick, Pos, pInput->m_Direction < 0 ? EVENT_LEFT : EVENT_RIGHT, true);
+    }
+
+    if((pInput->m_Jump & 1) && !(m_LastInput.m_Jump & 1))
+        RecordEvent(Tick, Pos, EVENT_JUMP, true);
+
+    if(pInput->m_Hook != m_LastInput.m_Hook)
+    {
+        RecordEvent(Tick, Pos, EVENT_HOOK, pInput->m_Hook != 0);
+        if(pInput->m_Hook)
+        {
+            vec2 HookDir = vec2(pInput->m_TargetX, pInput->m_TargetY);
+            if(length(HookDir) > 0.0f)
+            {
+                HookDir = normalize(HookDir);
+                float HookLength = GameClient()->m_aTuning[g_Config.m_ClDummy].m_HookLength;
+                vec2 TargetPos = Pos + HookDir * HookLength;
+                RecordEvent(Tick, TargetPos, EVENT_HOOK_TARGET, true);
+            }
+        }
+    }
+
+    int HookState = GameClient()->m_PredictedChar.m_HookState;
+    vec2 HookPos = GameClient()->m_PredictedChar.m_HookPos;
+    if(HookState == HOOK_GRABBED && m_LastHookState != HOOK_GRABBED)
+        RecordEvent(Tick, HookPos, EVENT_HOOK_ATTACH, true);
+    else if(HookState != HOOK_GRABBED && m_LastHookState == HOOK_GRABBED)
+        RecordEvent(Tick, HookPos, EVENT_HOOK_DETACH, true);
+    m_LastHookState = HookState;
 
     RecordEntry(pInput, Tick);
 
@@ -245,10 +461,20 @@ void CFujixTas::ConPlay(IConsole::IResult *pResult, void *pUserData)
         pSelf->StartPlay();
 }
 
+void CFujixTas::ConTest(IConsole::IResult *pResult, void *pUserData)
+{
+    CFujixTas *pSelf = static_cast<CFujixTas *>(pUserData);
+    if(pSelf->m_Testing)
+        pSelf->StopTest();
+    else
+        pSelf->StartTest();
+}
+
 void CFujixTas::OnConsoleInit()
 {
     Console()->Register("fujix_record", "", CFGFLAG_CLIENT, ConRecord, this, "Start/stop FUJIX TAS recording");
     Console()->Register("fujix_play", "", CFGFLAG_CLIENT, ConPlay, this, "Play FUJIX TAS for current map");
+    Console()->Register("fujix_test", "", CFGFLAG_CLIENT, ConTest, this, "Play FUJIX TAS as phantom");
 }
 
 void CFujixTas::OnMapLoad()
@@ -264,6 +490,29 @@ void CFujixTas::RewriteFile()
     m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
     for(const auto &e : m_vEntries)
         io_write(m_File, &e, sizeof(e));
+}
+
+void CFujixTas::RecordEvent(int Tick, vec2 Pos, EEventType Type, bool Pressed)
+{
+    if(!m_EventFile)
+        return;
+    if(!isfinite(Pos.x) || !isfinite(Pos.y))
+        return;
+
+    int RelTick = Tick - m_StartTick;
+    if(RelTick < 0)
+        return;
+
+    SEvent Ev{RelTick, Pos, Type, Pressed};
+    io_write(m_EventFile, &Ev, sizeof(Ev));
+    m_vEvents.push_back(Ev);
+
+    if(g_Config.m_ClFujixTasDebug)
+    {
+        char aBuf[128];
+        str_format(aBuf, sizeof(aBuf), "Hook event: tick=%d type=%d pos=(%.1f,%.1f)", RelTick, Type, Pos.x, Pos.y);
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix_debug", aBuf);
+    }
 }
 
 void CFujixTas::RollbackPhantom(int Ticks)
@@ -423,6 +672,67 @@ void CFujixTas::TickPhantomUpTo(int TargetTick)
             m_PhantomInput = m_PendingInputs.front().m_Input;
             m_PendingInputs.pop_front();
         }
+        if(m_Testing)
+        {
+            while(m_EventIndex < (int)m_vEvents.size())
+            {
+                const SEvent &Ev = m_vEvents[m_EventIndex];
+                int EventTick = m_TestStartTick + Ev.m_Tick;
+                if(EventTick > m_PhantomTick + m_PhantomStep)
+                    break;
+                switch(Ev.m_Type)
+                {
+                case EVENT_HOOK:
+                    m_PhantomInput.m_Hook = Ev.m_Pressed ? 1 : 0;
+                    break;
+                case EVENT_HOOK_ATTACH:
+                    m_PhantomInput.m_Hook = 1;
+                    m_PhantomCore.m_HookState = HOOK_GRABBED;
+                    m_PhantomCore.m_HookPos = Ev.m_Pos;
+                    m_PhantomCore.SetHookedPlayer(-1);
+                    m_PhantomCore.m_HookTick = 0;
+                    break;
+                case EVENT_HOOK_DETACH:
+                    m_PhantomInput.m_Hook = 0;
+                    m_PhantomCore.m_HookState = HOOK_RETRACTED;
+                    m_PhantomCore.m_HookPos = m_PhantomCore.m_Pos;
+                    m_PhantomCore.SetHookedPlayer(-1);
+                    m_PhantomCore.m_HookTick = 0;
+                    break;
+                case EVENT_HOOK_TARGET:
+                    if(Ev.m_Pressed)
+                    {
+                        vec2 Dir = Ev.m_Pos - m_PhantomCore.m_Pos;
+                        if(length(Dir) > 0.0f)
+                        {
+                            Dir = normalize(Dir);
+                            m_PhantomInput.m_TargetX = (int)(Dir.x * 256.0f);
+                            m_PhantomInput.m_TargetY = (int)(Dir.y * 256.0f);
+                        }
+                    }
+                    break;
+                case EVENT_LEFT:
+                    if(Ev.m_Pressed)
+                        m_PhantomInput.m_Direction = -1;
+                    else if(m_PhantomInput.m_Direction == -1)
+                        m_PhantomInput.m_Direction = 0;
+                    break;
+                case EVENT_RIGHT:
+                    if(Ev.m_Pressed)
+                        m_PhantomInput.m_Direction = 1;
+                    else if(m_PhantomInput.m_Direction == 1)
+                        m_PhantomInput.m_Direction = 0;
+                    break;
+                case EVENT_JUMP:
+                    if(Ev.m_Pressed)
+                        m_PhantomInput.m_Jump |= 1;
+                    else
+                        m_PhantomInput.m_Jump &= ~1;
+                    break;
+                }
+                m_EventIndex++;
+            }
+        }
         CNetObj_PlayerInput Input = m_PhantomInput;
         if(m_PhantomFreezeTime > 0)
         {
@@ -489,6 +799,11 @@ void CFujixTas::OnUpdate()
     else if(!g_Config.m_ClFujixTasPlay && m_Playing)
         StopPlay();
 
+    if(g_Config.m_ClFujixTasTest && !m_Testing)
+        StartTest();
+    else if(!g_Config.m_ClFujixTasTest && m_Testing)
+        StopTest();
+
     TickPhantom();
 }
 
@@ -506,6 +821,7 @@ void CFujixTas::OnRender()
     GameClient()->m_Players.RenderPlayer(&Prev, &Curr, &m_PhantomRenderInfo, -2);
 
     RenderFuturePath(g_Config.m_ClFujixTasPreviewTicks);
+    RenderRecommendedRoute(g_Config.m_ClFujixTasRouteTicks);
 }
 
 void CFujixTas::RenderFuturePath(int TicksAhead)
@@ -537,5 +853,49 @@ void CFujixTas::RenderFuturePath(int TicksAhead)
         Graphics()->LinesDraw(&Line, 1);
     }
     Graphics()->LinesEnd();
+}
+
+void CFujixTas::RenderRecommendedRoute(int TicksAhead)
+{
+    if(TicksAhead <= 0 || !m_PhantomActive)
+        return;
+
+    CFujixTas Tmp = *this;
+    Graphics()->TextureClear();
+    Graphics()->LinesBegin();
+    Graphics()->SetColor(0.0f, 1.0f, 0.0f, 1.0f);
+
+    std::vector<vec2> HookPos;
+
+    vec2 Prev = Tmp.m_PhantomCore.m_Pos;
+    int TargetTick = m_PhantomTick + TicksAhead;
+    while(Tmp.m_PhantomTick < TargetTick)
+    {
+        int StepTarget = minimum(TargetTick, Tmp.m_PhantomTick + Tmp.m_PhantomStep);
+        Tmp.TickPhantomUpTo(StepTarget);
+        vec2 Pos = Tmp.m_PhantomCore.m_Pos;
+        IGraphics::CLineItem Line(Prev.x, Prev.y, Pos.x, Pos.y);
+        Graphics()->LinesDraw(&Line, 1);
+
+        if(Tmp.m_PhantomInput.m_Hook)
+            HookPos.push_back(Pos);
+
+        Prev = Pos;
+    }
+
+    Graphics()->LinesEnd();
+
+    if(!HookPos.empty())
+    {
+        Graphics()->QuadsBegin();
+        for(const vec2 &Pos : HookPos)
+        {
+            IGraphics::CQuadItem Quad(Pos.x - 2.0f, Pos.y - 2.0f, 4.0f, 4.0f);
+            Graphics()->QuadsDraw(&Quad, 1);
+        }
+        Graphics()->QuadsEnd();
+    }
+
+    Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 }
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -25,7 +25,9 @@ private:
 
     bool m_Recording;
     bool m_Playing;
+    bool m_Testing;
     int m_StartTick;
+    int m_TestStartTick;
     int m_PlayStartTick;
     char m_aFilename[IO_MAX_PATH_LENGTH];
     IOHANDLE m_File;
@@ -33,6 +35,7 @@ private:
     int m_PlayIndex;
     int m_LastRecordTick;
     CNetObj_PlayerInput m_LastInput;
+    int m_LastHookState;
     CNetObj_PlayerInput m_CurrentInput;
     bool m_StopPending;
     int m_StopTick;
@@ -53,6 +56,8 @@ private:
     int m_PhantomStep;
     int m_LastPredTick;
 
+    int m_OldShowOthers;
+
     struct SPhantomState
     {
         int m_Tick;
@@ -62,6 +67,29 @@ private:
         int m_FreezeTime;
     };
     std::deque<SPhantomState> m_PhantomHistory;
+
+    enum EEventType
+    {
+        EVENT_HOOK,
+        EVENT_LEFT,
+        EVENT_RIGHT,
+        EVENT_JUMP,
+        EVENT_HOOK_ATTACH,
+        EVENT_HOOK_DETACH,
+        EVENT_HOOK_TARGET
+    };
+
+    struct SEvent
+    {
+        int m_Tick;
+        vec2 m_Pos;
+        EEventType m_Type;
+        bool m_Pressed; // used by hook/left/right, ignored for attach/detach
+    };
+
+    std::vector<SEvent> m_vEvents;
+    int m_EventIndex;
+    IOHANDLE m_EventFile;
 
     void GetPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
@@ -77,9 +105,13 @@ private:
     void RewriteFile();
     void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
     void FinishRecord();
+    void RecordEvent(int Tick, vec2 Pos, EEventType Type, bool Pressed);
+    void GetEventPath(char *pBuf, int Size) const;
+    void RenderRecommendedRoute(int TicksAhead);
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);
+    static void ConTest(IConsole::IResult *pResult, void *pUserData);
 
 public:
     CFujixTas();
@@ -94,8 +126,11 @@ public:
     void StopRecord();
     void StartPlay();
     void StopPlay();
+    void StartTest();
+    void StopTest();
     bool IsRecording() const { return m_Recording; }
     bool IsPlaying() const { return m_Playing; }
+    bool IsTesting() const { return m_Testing; }
     bool IsPhantomActive() const { return m_PhantomActive; }
     vec2 PhantomPos() const { return m_PhantomCore.m_Pos; }
     bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3463,20 +3463,25 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 void CMenus::RenderSettingsFujix(CUIRect MainView)
 {
-       CUIRect RecordButton, PlayButton;
+       CUIRect RecordButton, PlayButton, TestButton;
        MainView.HSplitTop(10.0f, nullptr, &MainView);
        MainView.HSplitTop(ms_ButtonHeight, &RecordButton, &MainView);
        MainView.HSplitTop(5.0f, nullptr, &MainView);
        MainView.HSplitTop(ms_ButtonHeight, &PlayButton, &MainView);
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &TestButton, &MainView);
 
-       static CButtonContainer s_RecordBtn, s_PlayBtn;
+       static CButtonContainer s_RecordBtn, s_PlayBtn, s_TestBtn;
        const char *pRecLabel = GameClient()->m_FujixTas.IsRecording() ? Localize("Stop") : Localize("Record");
        const char *pPlayLabel = GameClient()->m_FujixTas.IsPlaying() ? Localize("Stop") : Localize("Play");
+       const char *pTestLabel = GameClient()->m_FujixTas.IsTesting() ? Localize("Stop") : Localize("Play (test)");
 
        if(DoButton_Menu(&s_RecordBtn, pRecLabel, 0, &RecordButton))
                Console()->ExecuteLine("fujix_record");
        if(DoButton_Menu(&s_PlayBtn, pPlayLabel, 0, &PlayButton))
                Console()->ExecuteLine("fujix_play");
+       if(DoButton_Menu(&s_TestBtn, pTestLabel, 0, &TestButton))
+               Console()->ExecuteLine("fujix_test");
 
        CUIRect RewindBox, TicksBox;
        MainView.HSplitTop(5.0f, nullptr, &MainView);
@@ -3508,6 +3513,20 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
        char aPreviewBuf[64];
        str_format(aPreviewBuf, sizeof(aPreviewBuf), Localize("Preview ticks: %d"), g_Config.m_ClFujixTasPreviewTicks);
        Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPreviewTicks, &g_Config.m_ClFujixTasPreviewTicks, &PreviewBox, aPreviewBuf, 0, 200);
+
+       CUIRect ShowPlayersBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &ShowPlayersBox, &MainView);
+       static int s_ShowPlayersChk = 0;
+       if(DoButton_CheckBox(&s_ShowPlayersChk, Localize("Show players"), g_Config.m_ClFujixTasShowPlayers, &ShowPlayersBox))
+               g_Config.m_ClFujixTasShowPlayers ^= 1;
+
+       CUIRect RouteBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RouteBox, &MainView);
+       char aRouteBuf[64];
+       str_format(aRouteBuf, sizeof(aRouteBuf), Localize("Route ticks: %d"), g_Config.m_ClFujixTasRouteTicks);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasRouteTicks, &g_Config.m_ClFujixTasRouteTicks, &RouteBox, aRouteBuf, 0, 200);
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)


### PR DESCRIPTION
## Summary
- make recorded hook direction use `normalize` without taking address
- fetch hook length from tuning instead of missing config variable
- ensure old show-others opacity value is saved correctly
- adjust phantom hook direction normalization

## Testing
- `cargo test --locked` *(fails: environment variable `DDNET_TEST_LIBRARIES` required but not found)*

------
https://chatgpt.com/codex/tasks/task_e_684650826f88832c9680127a3421b491