### PR TITLE
Improve deepfly timing

### DIFF
--- a/data/touch_controls.json
+++ b/data/touch_controls.json
@@ -281,25 +281,107 @@
 				"command": "toggle cl_dummy 0 1"
 			}
 		},
-		{
-			"x": 883333,
-			"y": 16667,
-			"w": 100000,
-			"h": 100000,
-			"shape": "rect",
-			"visibilities": [
-				"ingame"
-			],
-			"behavior": {
-				"type": "predefined",
-				"id": "swap-action"
-			}
-		},
-		{
-			"x": 755000,
-			"y": 580000,
-			"w": 225000,
-			"h": 400000,
+                {
+                        "x": 883333,
+                        "y": 16667,
+                        "w": 100000,
+                        "h": 100000,
+                        "shape": "rect",
+                        "visibilities": [
+                                "ingame"
+                        ],
+                        "behavior": {
+                                "type": "predefined",
+                                "id": "swap-action"
+                        }
+                },
+                {
+                        "x": 600000,
+                        "y": 16667,
+                        "w": 83333,
+                        "h": 83333,
+                        "shape": "rect",
+                        "visibilities": [
+                                "extra-menu"
+                        ],
+                        "behavior": {
+                                "type": "bind",
+                                "label": "Freeze up",
+                                "label-type": "localized",
+                                "command": "fujix_freeze_up"
+                        }
+                },
+                {
+                        "x": 600000,
+                        "y": 100000,
+                        "w": 83333,
+                        "h": 83333,
+                        "shape": "rect",
+                        "visibilities": [
+                                "extra-menu"
+                        ],
+                        "behavior": {
+                                "type": "bind",
+                                "label": "Freeze down",
+                                "label-type": "localized",
+                                "command": "fujix_freeze_down"
+                        }
+                },
+                {
+                        "x": 683333,
+                        "y": 16667,
+                        "w": 83333,
+                        "h": 83333,
+                        "shape": "rect",
+                        "visibilities": [
+                                "extra-menu",
+                                "dummy-connected"
+                        ],
+                        "behavior": {
+                                "type": "bind",
+                                "label": "DEEPFLY",
+                                "label-type": "localized",
+                                "command": "toggle cl_fujix_deepfly 0 1"
+                        }
+                },
+                {
+                        "x": 683333,
+                        "y": 100000,
+                        "w": 83333,
+                        "h": 83333,
+                        "shape": "rect",
+                        "visibilities": [
+                                "extra-menu",
+                                "dummy-connected"
+                        ],
+                        "behavior": {
+                                "type": "bind",
+                                "label": "click D",
+                                "label-type": "localized",
+                                "command": "+click_d"
+                        }
+                },
+                {
+                        "x": 683333,
+                        "y": 233333,
+                        "w": 83333,
+                        "h": 83333,
+                        "shape": "rect",
+                        "visibilities": [
+                                "extra-menu"
+                        ],
+                        "behavior": {
+                                "type": "bind",
+                                "label": "click",
+                                "label-type": "localized",
+                                "command": "+fire"
+                        }
+                },
+                {
+                        "x": 755000,
+                        "y": 580000,
+                        "w": 225000,
+                        "h": 400000,
 			"shape": "circle",
 			"visibilities": [
 				"ingame"

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -649,6 +649,7 @@ MACRO_CONFIG_INT(ClRotationSpeed, cl_rotation_speed, 40, 1, 120, CFGFLAG_CLIENT 
 MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 40, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Menu camera speed")
 MACRO_CONFIG_INT(ClFujixTasRecord, cl_fujix_tas_record, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Record FUJIX TAS")
 MACRO_CONFIG_INT(ClFujixTasPlay, cl_fujix_tas_play, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS")
+MACRO_CONFIG_INT(ClFujixTasTest, cl_fujix_tas_test, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Play FUJIX TAS as phantom")
 MACRO_CONFIG_INT(ClFujixTasRewind, cl_fujix_tas_rewind, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Rollback phantom on tiles")
 MACRO_CONFIG_INT(ClFujixTasRewindTicks, cl_fujix_tas_rewind_ticks, 10, 5, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to rollback phantom")
 // Increased default and range to allow up to one phantom update per game tick
@@ -658,6 +659,18 @@ MACRO_CONFIG_INT(ClFujixTasPhantomTps, cl_fujix_tas_phantom_tps, 50, 1, 50, CFGF
 // Number of future ticks to visualize while playing TAS. Allows estimating the
 // upcoming path of the phantom on the HUD.
 MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks of phantom path preview")
+MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
+MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
+MACRO_CONFIG_INT(ClFujixFreeze, cl_fujix_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Hold player at set level using hook")
+MACRO_CONFIG_INT(ClFujixFreezeLevel, cl_fujix_freeze_level, 0, -10000, 10000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Vertical position for freeze mode")
+MACRO_CONFIG_INT(ClFujixDeepfly, cl_fujix_deepfly, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable automatic hammerfly for dummy")
+MACRO_CONFIG_INT(ClFujixDeepflyHoldTicks, cl_fujix_deepfly_hold_ticks, 2, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to hold hook when deepfly")
+MACRO_CONFIG_INT(ClFujixDeepflyReleaseTicks, cl_fujix_deepfly_release_ticks, 1, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to release hook when deepfly")
+MACRO_CONFIG_INT(ClDummyAutoClick, cl_dummy_auto_click, 0, 0, 1, CFGFLAG_CLIENT, "Dummy hits repeatedly while held")
+MACRO_CONFIG_INT(ClFujixAimbot, cl_fujix_aimbot, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable hook aimbot")
+MACRO_CONFIG_INT(ClFujixAimAngle, cl_fujix_aim_angle, 45, 1, 180, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Aimbot search angle in degrees")
+MACRO_CONFIG_INT(ClFujixAimLines, cl_fujix_aim_lines, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show aimbot angle lines")
+MACRO_CONFIG_INT(UiFujixPage, ui_fujix_page, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Fujix settings sub page")
 
 MACRO_CONFIG_INT(ClBackgroundShowTilesLayers, cl_background_show_tiles_layers, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether draw tiles layers when using custom background (entities)")
 MACRO_CONFIG_INT(SvShowOthers, sv_show_others, 1, 0, 1, CFGFLAG_SERVER, "Whether players can use the command showothers or not")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -11,6 +11,7 @@
 #include <game/gamecore.h>
 #include <game/client/components/players.h>
 #include <base/system.h>
+#include <cmath>
 
 const char *CFujixTas::ms_pFujixDir = "fujix";
 
@@ -18,14 +19,25 @@ CFujixTas::CFujixTas()
 {
     m_Recording = false;
     m_Playing = false;
+    m_Testing = false;
     m_StartTick = 0;
+    m_TestStartTick = 0;
     m_PlayStartTick = 0;
     m_File = nullptr;
+    m_HookFile = nullptr;
+    m_EventFile = nullptr;
     m_PlayIndex = 0;
+    m_PlayHookIndex = 0;
+    m_PlayActionIndex = 0;
     m_LastRecordTick = -1;
     mem_zero(&m_LastInput, sizeof(m_LastInput));
     m_aFilename[0] = '\0';
+    m_aHookFilename[0] = '\0';
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
+    m_LastHookState = HOOK_IDLE;
+    m_HookRecording = false;
+    m_PhantomHookIndex = 0;
+    m_PhantomActionIndex = 0;
     m_StopPending = false;
     m_StopTick = -1;
     m_PhantomActive = false;
@@ -36,6 +48,11 @@ CFujixTas::CFujixTas()
     m_LastPredTick = 0;
     m_PhantomHistory.clear();
     m_PendingInputs.clear();
+    m_OldShowOthers = g_Config.m_ClShowOthersAlpha;
+    m_FreezeActive = false;
+    m_FreezeLevel = 0.0f;
+    m_FreezeHookTicks = 0;
+    m_FreezeHookCooldown = 0;
 }
 
 void CFujixTas::GetPath(char *pBuf, int Size) const
@@ -44,12 +61,37 @@ void CFujixTas::GetPath(char *pBuf, int Size) const
     str_format(pBuf, Size, "%s/%s.fjx", ms_pFujixDir, pMap);
 }
 
+void CFujixTas::GetHookPath(char *pBuf, int Size) const
+{
+    const char *pMap = Client()->GetCurrentMap();
+    str_format(pBuf, Size, "%s/%s.fjh", ms_pFujixDir, pMap);
+}
+
+void CFujixTas::GetEventPath(char *pBuf, int Size) const
+{
+    const char *pMap = Client()->GetCurrentMap();
+    str_format(pBuf, Size, "%s/%s.fja", ms_pFujixDir, pMap);
+}
+
+void CFujixTas::RecordActionEvent(EActionType Type, vec2 Pos, int Tick)
+{
+    if(!m_Recording || !m_EventFile)
+        return;
+    SActionEvent Ev;
+    Ev.m_Tick = Tick - m_StartTick;
+    Ev.m_Pos = Pos;
+    Ev.m_Type = Type;
+    io_write(m_EventFile, &Ev, sizeof(Ev));
+    m_vActionEvents.push_back(Ev);
+}
+
 void CFujixTas::RecordEntry(const CNetObj_PlayerInput *pInput, int Tick)
 {
     if(!m_Recording || !m_File)
         return;
     bool Active = mem_comp(pInput, &m_LastInput, sizeof(*pInput)) != 0;
-    SEntry e{Tick - m_StartTick, *pInput, Active};
+    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+    SEntry e{Tick - m_StartTick, *pInput, Pos, Active};
     io_write(m_File, &e, sizeof(e));
     m_vEntries.push_back(e);
     m_LastInput = *pInput;
@@ -77,6 +119,7 @@ void CFujixTas::UpdatePlaybackInput()
         return;
 
     int PredTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_CurrentInput.m_Jump = 0;
     while(m_PlayIndex < (int)m_vEntries.size() &&
           m_PlayStartTick + m_vEntries[m_PlayIndex].m_Tick <= PredTick)
     {
@@ -84,7 +127,53 @@ void CFujixTas::UpdatePlaybackInput()
         m_PlayIndex++;
     }
 
+    // default hook state from entries is ignored
+    m_CurrentInput.m_Hook = 0;
+
+    while(m_PlayHookIndex < (int)m_vHookEvents.size() &&
+          m_PlayStartTick + m_vHookEvents[m_PlayHookIndex].m_EndTick <= PredTick)
+        m_PlayHookIndex++;
+
+    while(m_PlayActionIndex < (int)m_vActionEvents.size() &&
+          m_PlayStartTick + m_vActionEvents[m_PlayActionIndex].m_Tick <= PredTick)
+    {
+        const SActionEvent &Ev = m_vActionEvents[m_PlayActionIndex];
+        switch(Ev.m_Type)
+        {
+        case ACTION_LEFT_PRESS: m_CurrentInput.m_Direction = -1; break;
+        case ACTION_LEFT_RELEASE: if(m_CurrentInput.m_Direction < 0) m_CurrentInput.m_Direction = 0; break;
+        case ACTION_RIGHT_PRESS: m_CurrentInput.m_Direction = 1; break;
+        case ACTION_RIGHT_RELEASE: if(m_CurrentInput.m_Direction > 0) m_CurrentInput.m_Direction = 0; break;
+        case ACTION_HOOK_PRESS: m_CurrentInput.m_Hook = 1; break;
+        case ACTION_HOOK_RELEASE: m_CurrentInput.m_Hook = 0; break;
+        case ACTION_JUMP: m_CurrentInput.m_Jump = 1; break;
+        }
+        m_PlayActionIndex++;
+    }
+
+    if(m_PlayHookIndex < (int)m_vHookEvents.size())
+    {
+        const SHookEvent &Ev = m_vHookEvents[m_PlayHookIndex];
+        int Start = m_PlayStartTick + Ev.m_StartTick;
+        int End = m_PlayStartTick + Ev.m_EndTick;
+        if(PredTick >= Start && PredTick < End)
+        {
+            m_CurrentInput.m_Hook = 1;
+            vec2 Target((Ev.m_TileX + 0.5f) * 32.0f, (Ev.m_TileY + 0.5f) * 32.0f);
+            vec2 Dir = Target - GameClient()->m_PredictedChar.m_Pos;
+            if(length(Dir) > 0.0f)
+            {
+                Dir = normalize(Dir);
+                m_CurrentInput.m_TargetX = (int)(Dir.x * 256);
+                m_CurrentInput.m_TargetY = (int)(Dir.y * 256);
+            }
+        }
+    }
+
+
     if(m_PlayIndex >= (int)m_vEntries.size() &&
+       m_PlayHookIndex >= (int)m_vHookEvents.size() &&
+       m_PlayActionIndex >= (int)m_vActionEvents.size() &&
        PredTick >= m_PlayStartTick + m_vEntries.back().m_Tick)
     {
         m_Playing = false;
@@ -97,11 +186,34 @@ void CFujixTas::StartRecord()
     if(m_Recording)
         return;
     GetPath(m_aFilename, sizeof(m_aFilename));
+    GetHookPath(m_aHookFilename, sizeof(m_aHookFilename));
+    char aEventPath[IO_MAX_PATH_LENGTH];
+    GetEventPath(aEventPath, sizeof(aEventPath));
     Storage()->CreateFolder(ms_pFujixDir, IStorage::TYPE_SAVE);
     m_File = Storage()->OpenFile(m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
     if(!m_File)
     {
         Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for recording");
+        if(m_File)
+            io_close(m_File);
+        m_File = nullptr;
+        m_HookFile = nullptr;
+        return;
+    }
+    m_HookFile = Storage()->OpenFile(m_aHookFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    m_EventFile = Storage()->OpenFile(aEventPath, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+    if(!m_HookFile || !m_EventFile)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open hook file for recording");
+        if(m_File)
+            io_close(m_File);
+        m_File = nullptr;
+        if(m_HookFile)
+            io_close(m_HookFile);
+        if(m_EventFile)
+            io_close(m_EventFile);
+        m_HookFile = nullptr;
+        m_EventFile = nullptr;
         return;
     }
     // start recording on the next predicted tick to align with
@@ -109,9 +221,16 @@ void CFujixTas::StartRecord()
     m_StartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_LastRecordTick = m_StartTick - 1;
     mem_zero(&m_LastInput, sizeof(m_LastInput));
+    m_LastHookState = GameClient()->m_PredictedChar.m_HookState;
+    m_HookRecording = false;
     m_Recording = true;
     g_Config.m_ClFujixTasRecord = 1;
     m_vEntries.clear();
+    m_vHookEvents.clear();
+    m_vActionEvents.clear();
+    m_PlayHookIndex = 0;
+    m_PlayActionIndex = 0;
+    m_PhantomHookIndex = 0;
     m_PhantomHistory.clear();
     m_PendingInputs.clear();
 
@@ -132,16 +251,36 @@ void CFujixTas::StartRecord()
     mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
     m_PhantomFreezeTime = 0;
     m_PhantomActive = true;
+    m_PhantomCore.m_HookHitDisabled = true;
+    m_PhantomCore.m_CollisionDisabled = true;
     m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+
+    m_OldShowOthers = g_Config.m_ClShowOthersAlpha;
+    if(!g_Config.m_ClFujixTasShowPlayers)
+        g_Config.m_ClShowOthersAlpha = 0;
 }
 
 void CFujixTas::FinishRecord()
 {
     if(!m_Recording)
         return;
+    if(m_HookRecording)
+    {
+        m_CurHookEvent.m_EndTick = Client()->PredGameTick(g_Config.m_ClDummy) - m_StartTick;
+        if(m_HookFile)
+            io_write(m_HookFile, &m_CurHookEvent, sizeof(m_CurHookEvent));
+        m_vHookEvents.push_back(m_CurHookEvent);
+        m_HookRecording = false;
+    }
     if(m_File)
         io_close(m_File);
+    if(m_HookFile)
+        io_close(m_HookFile);
+    if(m_EventFile)
+        io_close(m_EventFile);
     m_File = nullptr;
+    m_HookFile = nullptr;
+    m_EventFile = nullptr;
     m_Recording = false;
     g_Config.m_ClFujixTasRecord = 0;
     m_PhantomActive = false;
@@ -149,6 +288,7 @@ void CFujixTas::FinishRecord()
     m_LastRecordTick = -1;
     m_StopPending = false;
     m_StopTick = -1;
+    g_Config.m_ClShowOthersAlpha = m_OldShowOthers;
 }
 
 void CFujixTas::StopRecord()
@@ -185,9 +325,33 @@ void CFujixTas::StartPlay()
         m_vEntries.push_back(e);
     io_close(File);
 
+    char aHookPath[IO_MAX_PATH_LENGTH];
+    GetHookPath(aHookPath, sizeof(aHookPath));
+    IOHANDLE HookFile = Storage()->OpenFile(aHookPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    char aEventPath[IO_MAX_PATH_LENGTH];
+    GetEventPath(aEventPath, sizeof(aEventPath));
+    IOHANDLE EventFile = Storage()->OpenFile(aEventPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    m_vHookEvents.clear();
+    m_vActionEvents.clear();
+    SHookEvent he;
+    if(HookFile)
+    {
+        while(io_read(HookFile, &he, sizeof(he)) == sizeof(he))
+            m_vHookEvents.push_back(he);
+        io_close(HookFile);
+    }
+    if(EventFile)
+    {
+        SActionEvent ev;
+        while(io_read(EventFile, &ev, sizeof(ev)) == sizeof(ev))
+            m_vActionEvents.push_back(ev);
+        io_close(EventFile);
+    }
+    m_PlayHookIndex = 0;
+    m_PlayActionIndex = 0;
+    m_PhantomHookIndex = 0;
+
     m_PlayIndex = 0;
-    // similar to recording, start playback on the next tick so the
-    // first stored input is applied exactly when OnSnapInput runs
     m_PlayStartTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
     m_Playing = !m_vEntries.empty();
     if(m_Playing)
@@ -202,9 +366,99 @@ void CFujixTas::StopPlay()
     m_Playing = false;
     g_Config.m_ClFujixTasPlay = 0;
     m_vEntries.clear();
+    m_vHookEvents.clear();
+    m_vActionEvents.clear();
     m_PlayIndex = 0;
+    m_PlayHookIndex = 0;
+    m_PlayActionIndex = 0;
     m_PlayStartTick = 0;
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
+}
+
+void CFujixTas::StartTest()
+{
+    if(m_Testing)
+        StopTest();
+
+    char aPath[IO_MAX_PATH_LENGTH];
+    GetPath(aPath, sizeof(aPath));
+    IOHANDLE File = Storage()->OpenFile(aPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    if(!File)
+    {
+        Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "fujix", "failed to open file for test");
+        return;
+    }
+
+    char aHookPath[IO_MAX_PATH_LENGTH];
+    GetHookPath(aHookPath, sizeof(aHookPath));
+    IOHANDLE HookFile = Storage()->OpenFile(aHookPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+    char aEventPath[IO_MAX_PATH_LENGTH];
+    GetEventPath(aEventPath, sizeof(aEventPath));
+    IOHANDLE EventFile = Storage()->OpenFile(aEventPath, IOFLAG_READ, IStorage::TYPE_SAVE);
+
+    m_vEntries.clear();
+    SEntry e;
+    while(io_read(File, &e, sizeof(e)) == sizeof(e))
+        m_vEntries.push_back(e);
+    io_close(File);
+
+    m_vHookEvents.clear();
+    SHookEvent he;
+    if(HookFile)
+    {
+        while(io_read(HookFile, &he, sizeof(he)) == sizeof(he))
+            m_vHookEvents.push_back(he);
+        io_close(HookFile);
+    }
+    if(EventFile)
+    {
+        SActionEvent ev;
+        while(io_read(EventFile, &ev, sizeof(ev)) == sizeof(ev))
+            m_vActionEvents.push_back(ev);
+        io_close(EventFile);
+    }
+    m_PhantomHookIndex = 0;
+    m_PhantomActionIndex = 0;
+
+    // init phantom at current position
+    if(GameClient()->m_Snap.m_LocalClientId >= 0)
+    {
+        m_PhantomCore = GameClient()->m_PredictedChar;
+        m_PhantomPrevCore = m_PhantomCore;
+        m_PhantomCore.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        m_PhantomRenderInfo = GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_RenderInfo;
+    }
+    m_PhantomTick = Client()->PredGameTick(g_Config.m_ClDummy);
+    m_PhantomStep = maximum(1, Client()->GameTickSpeed() / g_Config.m_ClFujixTasPhantomTps);
+    m_LastPredTick = m_PhantomTick;
+    mem_zero(&m_PhantomInput, sizeof(m_PhantomInput));
+    m_PhantomFreezeTime = 0;
+    m_PhantomActive = true;
+    m_PhantomCore.m_HookHitDisabled = true;
+    m_PhantomCore.m_CollisionDisabled = true;
+    m_PhantomHistory.clear();
+    m_PhantomHistory.push_back({m_PhantomTick, m_PhantomCore, m_PhantomPrevCore, m_PhantomInput, m_PhantomFreezeTime});
+
+    m_PendingInputs.clear();
+    m_TestStartTick = m_PhantomTick + 1;
+    for(const auto &Entry : m_vEntries)
+        m_PendingInputs.push_back({m_TestStartTick + Entry.m_Tick, Entry.m_Input});
+
+    m_Testing = !m_vEntries.empty();
+    if(m_Testing)
+        g_Config.m_ClFujixTasTest = 1;
+}
+
+void CFujixTas::StopTest()
+{
+    m_Testing = false;
+    g_Config.m_ClFujixTasTest = 0;
+    m_PhantomActive = false;
+    m_PendingInputs.clear();
+    m_PhantomHistory.clear();
+    m_vEntries.clear();
+    m_vHookEvents.clear();
+    m_vActionEvents.clear();
 }
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
@@ -218,12 +472,54 @@ void CFujixTas::RecordInput(const CNetObj_PlayerInput *pInput, int Tick)
         return;
     m_LastRecordTick = Tick;
 
+    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+
     RecordEntry(pInput, Tick);
 
     if(m_Recording)
     {
         m_PendingInputs.push_back({Tick, *pInput});
         TickPhantomUpTo(Tick);
+
+        if(pInput->m_Direction < 0 && m_LastInput.m_Direction >= 0)
+            RecordActionEvent(ACTION_LEFT_PRESS, Pos, Tick);
+        if(pInput->m_Direction >= 0 && m_LastInput.m_Direction < 0)
+            RecordActionEvent(ACTION_LEFT_RELEASE, Pos, Tick);
+        if(pInput->m_Direction > 0 && m_LastInput.m_Direction <= 0)
+            RecordActionEvent(ACTION_RIGHT_PRESS, Pos, Tick);
+        if(pInput->m_Direction <= 0 && m_LastInput.m_Direction > 0)
+            RecordActionEvent(ACTION_RIGHT_RELEASE, Pos, Tick);
+        if(pInput->m_Hook && !m_LastInput.m_Hook)
+            RecordActionEvent(ACTION_HOOK_PRESS, Pos, Tick);
+        if(!pInput->m_Hook && m_LastInput.m_Hook)
+            RecordActionEvent(ACTION_HOOK_RELEASE, Pos, Tick);
+        if(pInput->m_Jump && !m_LastInput.m_Jump)
+            RecordActionEvent(ACTION_JUMP, Pos, Tick);
+
+        if(!m_HookRecording && pInput->m_Hook)
+        {
+            m_CurHookEvent.m_StartTick = Tick - m_StartTick;
+            m_CurHookEvent.m_TileX = -1;
+            m_CurHookEvent.m_TileY = -1;
+            m_HookRecording = true;
+        }
+        if(m_HookRecording)
+        {
+            if(m_CurHookEvent.m_TileX == -1 && GameClient()->m_PredictedChar.m_HookState == HOOK_GRABBED && GameClient()->m_PredictedChar.HookedPlayer() == -1)
+            {
+                vec2 HPos = GameClient()->m_PredictedChar.m_HookPos;
+                m_CurHookEvent.m_TileX = (int)floor(HPos.x / 32.0f);
+                m_CurHookEvent.m_TileY = (int)floor(HPos.y / 32.0f);
+            }
+            if(!pInput->m_Hook)
+            {
+                m_CurHookEvent.m_EndTick = Tick - m_StartTick;
+                if(m_HookFile)
+                    io_write(m_HookFile, &m_CurHookEvent, sizeof(m_CurHookEvent));
+                m_vHookEvents.push_back(m_CurHookEvent);
+                m_HookRecording = false;
+            }
+        }
     }
 }
 
@@ -245,10 +541,32 @@ void CFujixTas::ConPlay(IConsole::IResult *pResult, void *pUserData)
         pSelf->StartPlay();
 }
 
+void CFujixTas::ConTest(IConsole::IResult *pResult, void *pUserData)
+{
+    CFujixTas *pSelf = static_cast<CFujixTas *>(pUserData);
+    if(pSelf->m_Testing)
+        pSelf->StopTest();
+    else
+        pSelf->StartTest();
+}
+
+void CFujixTas::ConFreezeUp(IConsole::IResult *pResult, void *pUserData)
+{
+    g_Config.m_ClFujixFreezeLevel -= 32;
+}
+
+void CFujixTas::ConFreezeDown(IConsole::IResult *pResult, void *pUserData)
+{
+    g_Config.m_ClFujixFreezeLevel += 32;
+}
+
 void CFujixTas::OnConsoleInit()
 {
     Console()->Register("fujix_record", "", CFGFLAG_CLIENT, ConRecord, this, "Start/stop FUJIX TAS recording");
     Console()->Register("fujix_play", "", CFGFLAG_CLIENT, ConPlay, this, "Play FUJIX TAS for current map");
+    Console()->Register("fujix_test", "", CFGFLAG_CLIENT, ConTest, this, "Play FUJIX TAS as phantom");
+    Console()->Register("fujix_freeze_up", "", CFGFLAG_CLIENT, ConFreezeUp, this, "Raise freeze level by one block");
+    Console()->Register("fujix_freeze_down", "", CFGFLAG_CLIENT, ConFreezeDown, this, "Lower freeze level by one block");
 }
 
 void CFujixTas::OnMapLoad()
@@ -424,6 +742,46 @@ void CFujixTas::TickPhantomUpTo(int TargetTick)
             m_PendingInputs.pop_front();
         }
         CNetObj_PlayerInput Input = m_PhantomInput;
+
+        int BaseTick = m_Recording ? m_StartTick : m_TestStartTick;
+        while(m_PhantomHookIndex < (int)m_vHookEvents.size() && BaseTick + m_vHookEvents[m_PhantomHookIndex].m_EndTick <= m_PhantomTick)
+            m_PhantomHookIndex++;
+        while(m_PhantomActionIndex < (int)m_vActionEvents.size() && BaseTick + m_vActionEvents[m_PhantomActionIndex].m_Tick <= m_PhantomTick)
+        {
+            const SActionEvent &Ev = m_vActionEvents[m_PhantomActionIndex];
+            switch(Ev.m_Type)
+            {
+            case ACTION_LEFT_PRESS: Input.m_Direction = -1; break;
+            case ACTION_LEFT_RELEASE: if(Input.m_Direction < 0) Input.m_Direction = 0; break;
+            case ACTION_RIGHT_PRESS: Input.m_Direction = 1; break;
+            case ACTION_RIGHT_RELEASE: if(Input.m_Direction > 0) Input.m_Direction = 0; break;
+            case ACTION_HOOK_PRESS: Input.m_Hook = 1; break;
+            case ACTION_HOOK_RELEASE: Input.m_Hook = 0; break;
+            case ACTION_JUMP: Input.m_Jump = 1; break;
+            }
+            m_PhantomActionIndex++;
+        }
+        if(m_PhantomHookIndex < (int)m_vHookEvents.size())
+        {
+            const SHookEvent &Ev = m_vHookEvents[m_PhantomHookIndex];
+            int Start = BaseTick + Ev.m_StartTick;
+            int End = BaseTick + Ev.m_EndTick;
+            if(m_PhantomTick >= Start && m_PhantomTick < End)
+            {
+                Input.m_Hook = 1;
+                vec2 Target((Ev.m_TileX + 0.5f) * 32.0f, (Ev.m_TileY + 0.5f) * 32.0f);
+                vec2 Dir = Target - m_PhantomCore.m_Pos;
+                if(length(Dir) > 0.0f)
+                {
+                    Dir = normalize(Dir);
+                    Input.m_TargetX = (int)(Dir.x * 256);
+                    Input.m_TargetY = (int)(Dir.y * 256);
+                }
+            }
+            else
+                Input.m_Hook = 0;
+        }
+
         if(m_PhantomFreezeTime > 0)
         {
             Input.m_Direction = 0;
@@ -489,14 +847,26 @@ void CFujixTas::OnUpdate()
     else if(!g_Config.m_ClFujixTasPlay && m_Playing)
         StopPlay();
 
+    if(g_Config.m_ClFujixTasTest && !m_Testing)
+        StartTest();
+    else if(!g_Config.m_ClFujixTasTest && m_Testing)
+        StopTest();
+
+    if(g_Config.m_ClFujixFreeze && !m_FreezeActive)
+        StartFreeze();
+    else if(!g_Config.m_ClFujixFreeze && m_FreezeActive)
+        StopFreeze();
+
+    if(m_FreezeActive)
+        m_FreezeLevel = g_Config.m_ClFujixFreezeLevel;
+
     TickPhantom();
 }
 
 void CFujixTas::OnRender()
 {
-    if(!m_PhantomActive)
-        return;
-
+    if(m_PhantomActive)
+    {
     CNetObj_Character Prev, Curr;
     CoreToCharacter(m_PhantomPrevCore, &Prev, m_PhantomTick - m_PhantomStep);
     CoreToCharacter(m_PhantomCore, &Curr, m_PhantomTick);
@@ -506,6 +876,13 @@ void CFujixTas::OnRender()
     GameClient()->m_Players.RenderPlayer(&Prev, &Curr, &m_PhantomRenderInfo, -2);
 
     RenderFuturePath(g_Config.m_ClFujixTasPreviewTicks);
+    RenderRecommendedRoute(g_Config.m_ClFujixTasRouteTicks);
+    }
+
+    if(m_FreezeActive)
+        RenderFreezeIndicator();
+
+    RenderAimLines();
 }
 
 void CFujixTas::RenderFuturePath(int TicksAhead)
@@ -536,6 +913,164 @@ void CFujixTas::RenderFuturePath(int TicksAhead)
         IGraphics::CLineItem Line(Points[i - 1].x, Points[i - 1].y, Points[i].x, Points[i].y);
         Graphics()->LinesDraw(&Line, 1);
     }
+    Graphics()->LinesEnd();
+}
+
+void CFujixTas::RenderRecommendedRoute(int TicksAhead)
+{
+    if(TicksAhead <= 0 || !m_PhantomActive)
+        return;
+
+    CFujixTas Tmp = *this;
+    Graphics()->TextureClear();
+    Graphics()->LinesBegin();
+    Graphics()->SetColor(0.0f, 1.0f, 0.0f, 1.0f);
+
+    std::vector<vec2> HookPos;
+
+    vec2 Prev = Tmp.m_PhantomCore.m_Pos;
+    int TargetTick = m_PhantomTick + TicksAhead;
+    while(Tmp.m_PhantomTick < TargetTick)
+    {
+        int StepTarget = minimum(TargetTick, Tmp.m_PhantomTick + Tmp.m_PhantomStep);
+        Tmp.TickPhantomUpTo(StepTarget);
+        vec2 Pos = Tmp.m_PhantomCore.m_Pos;
+        IGraphics::CLineItem Line(Prev.x, Prev.y, Pos.x, Pos.y);
+        Graphics()->LinesDraw(&Line, 1);
+
+        if(Tmp.m_PhantomInput.m_Hook)
+            HookPos.push_back(Pos);
+
+        Prev = Pos;
+    }
+
+    Graphics()->LinesEnd();
+
+    if(!HookPos.empty())
+    {
+        Graphics()->QuadsBegin();
+        for(const vec2 &Pos : HookPos)
+        {
+            IGraphics::CQuadItem Quad(Pos.x - 2.0f, Pos.y - 2.0f, 4.0f, 4.0f);
+            Graphics()->QuadsDraw(&Quad, 1);
+        }
+        Graphics()->QuadsEnd();
+    }
+
+    Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+void CFujixTas::StartFreeze()
+{
+    if(m_FreezeActive)
+        return;
+    m_FreezeActive = true;
+    m_FreezeLevel = GameClient()->m_PredictedChar.m_Pos.y;
+    g_Config.m_ClFujixFreezeLevel = (int)m_FreezeLevel;
+    m_FreezeHookTicks = 0;
+    m_FreezeHookCooldown = 0;
+}
+
+void CFujixTas::StopFreeze()
+{
+    m_FreezeActive = false;
+    m_FreezeHookTicks = 0;
+    m_FreezeHookCooldown = 0;
+}
+
+void CFujixTas::UpdateFreezeInput(CNetObj_PlayerInput *pInput)
+{
+    if(!m_FreezeActive || !pInput)
+        return;
+
+    const CTuningParams *pTuning = GameClient()->GetTuning(0);
+
+    if(m_FreezeHookTicks > 0)
+    {
+        pInput->m_Hook = 1;
+        pInput->m_TargetX = 0;
+        pInput->m_TargetY = -256;
+        m_FreezeHookTicks--;
+        return;
+    }
+
+    if(m_FreezeHookCooldown > 0)
+    {
+        pInput->m_Hook = 0;
+        m_FreezeHookCooldown--;
+        return;
+    }
+
+    const int PredictTicks = 20;
+    float PosY = GameClient()->m_PredictedChar.m_Pos.y;
+    float VelY = GameClient()->m_PredictedChar.m_Vel.y;
+    float FutureY = PosY + VelY * PredictTicks + pTuning->m_Gravity * PredictTicks * PredictTicks / 2.0f;
+
+    if(FutureY > m_FreezeLevel + 1.0f)
+    {
+        int Hold = 1;
+        float SimPos = PosY;
+        float SimVel = VelY;
+        for(int t = 0; t < PredictTicks; t++)
+        {
+            SimVel += pTuning->m_Gravity - pTuning->m_HookDragAccel;
+            SimPos += SimVel;
+            if(SimPos <= m_FreezeLevel)
+            {
+                Hold = t + 1;
+                break;
+            }
+        }
+        pInput->m_Hook = 1;
+        pInput->m_TargetX = 0;
+        pInput->m_TargetY = -256;
+        m_FreezeHookTicks = Hold;
+        m_FreezeHookCooldown = 2;
+    }
+    else
+    {
+        pInput->m_Hook = 0;
+    }
+}
+
+void CFujixTas::RenderFreezeIndicator()
+{
+    if(!m_FreezeActive)
+        return;
+
+    Graphics()->TextureClear();
+    Graphics()->LinesBegin();
+    Graphics()->SetColor(1.0f, 0.0f, 0.0f, 0.5f);
+    float y = m_FreezeLevel;
+    IGraphics::CLineItem Line(-100000.0f, y, 100000.0f, y);
+    Graphics()->LinesDraw(&Line, 1);
+    Graphics()->LinesEnd();
+    Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+void CFujixTas::RenderAimLines()
+{
+    if(!g_Config.m_ClFujixAimbot || !g_Config.m_ClFujixAimLines)
+        return;
+
+    vec2 Pos = GameClient()->m_LocalCharacterPos;
+    vec2 Mouse = GameClient()->m_Controls.m_aMousePos[g_Config.m_ClDummy];
+    vec2 Dir = normalize(Mouse);
+    if(length(Mouse) == 0)
+        Dir = vec2(1, 0);
+
+    float BaseAng = angle(Dir);
+    float Off = g_Config.m_ClFujixAimAngle * pi / 180.0f;
+
+    vec2 Up = direction(BaseAng + Off);
+    vec2 Down = direction(BaseAng - Off);
+
+    Graphics()->TextureClear();
+    Graphics()->LinesBegin();
+    IGraphics::CLineItem L1(Pos.x, Pos.y, Pos.x + Up.x * 500.0f, Pos.y + Up.y * 500.0f);
+    IGraphics::CLineItem L2(Pos.x, Pos.y, Pos.x + Down.x * 500.0f, Pos.y + Down.y * 500.0f);
+    Graphics()->LinesDraw(&L1, 1);
+    Graphics()->LinesDraw(&L2, 1);
     Graphics()->LinesEnd();
 }
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -20,20 +20,61 @@ private:
     {
         int m_Tick;
         CNetObj_PlayerInput m_Input;
+        vec2 m_Pos; // player position this tick
         bool m_Active; // true if any input changed this tick
+    };
+
+    enum EActionType
+    {
+        ACTION_LEFT_PRESS,
+        ACTION_LEFT_RELEASE,
+        ACTION_RIGHT_PRESS,
+        ACTION_RIGHT_RELEASE,
+        ACTION_HOOK_PRESS,
+        ACTION_HOOK_RELEASE,
+        ACTION_JUMP
+    };
+
+    struct SActionEvent
+    {
+        int m_Tick;
+        vec2 m_Pos;
+        EActionType m_Type;
+    };
+
+    struct SHookEvent
+    {
+        int m_StartTick;
+        int m_EndTick;
+        int m_TileX;
+        int m_TileY;
     };
 
     bool m_Recording;
     bool m_Playing;
+    bool m_Testing;
     int m_StartTick;
+    int m_TestStartTick;
     int m_PlayStartTick;
     char m_aFilename[IO_MAX_PATH_LENGTH];
+    char m_aHookFilename[IO_MAX_PATH_LENGTH];
     IOHANDLE m_File;
+    IOHANDLE m_HookFile;
+    IOHANDLE m_EventFile;
     std::vector<SEntry> m_vEntries;
+    std::vector<SHookEvent> m_vHookEvents;
+    std::vector<SActionEvent> m_vActionEvents;
     int m_PlayIndex;
+    int m_PlayHookIndex;
+    int m_PlayActionIndex;
     int m_LastRecordTick;
     CNetObj_PlayerInput m_LastInput;
     CNetObj_PlayerInput m_CurrentInput;
+    int m_LastHookState;
+    bool m_HookRecording;
+    SHookEvent m_CurHookEvent;
+    int m_PhantomHookIndex;
+    int m_PhantomActionIndex;
     bool m_StopPending;
     int m_StopTick;
 
@@ -53,6 +94,13 @@ private:
     int m_PhantomStep;
     int m_LastPredTick;
 
+    bool m_FreezeActive;
+    float m_FreezeLevel;
+    int m_FreezeHookTicks;
+    int m_FreezeHookCooldown;
+
+    int m_OldShowOthers;
+
     struct SPhantomState
     {
         int m_Tick;
@@ -64,7 +112,10 @@ private:
     std::deque<SPhantomState> m_PhantomHistory;
 
     void GetPath(char *pBuf, int Size) const;
+    void GetHookPath(char *pBuf, int Size) const;
+    void GetEventPath(char *pBuf, int Size) const;
     void RecordEntry(const CNetObj_PlayerInput *pInput, int Tick);
+    void RecordActionEvent(EActionType Type, vec2 Pos, int Tick);
     bool FetchEntry(CNetObj_PlayerInput *pInput);
     void UpdatePlaybackInput();
     void TickPhantom();
@@ -77,9 +128,13 @@ private:
     void RewriteFile();
     void CoreToCharacter(const CCharacterCore &Core, CNetObj_Character *pChar, int Tick);
     void FinishRecord();
+    void RenderRecommendedRoute(int TicksAhead);
 
     static void ConRecord(IConsole::IResult *pResult, void *pUserData);
     static void ConPlay(IConsole::IResult *pResult, void *pUserData);
+    static void ConTest(IConsole::IResult *pResult, void *pUserData);
+    static void ConFreezeUp(IConsole::IResult *pResult, void *pUserData);
+    static void ConFreezeDown(IConsole::IResult *pResult, void *pUserData);
 
 public:
     CFujixTas();
@@ -94,13 +149,21 @@ public:
     void StopRecord();
     void StartPlay();
     void StopPlay();
+    void StartTest();
+    void StopTest();
     bool IsRecording() const { return m_Recording; }
     bool IsPlaying() const { return m_Playing; }
+    bool IsTesting() const { return m_Testing; }
     bool IsPhantomActive() const { return m_PhantomActive; }
     vec2 PhantomPos() const { return m_PhantomCore.m_Pos; }
     bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
     void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
     void MaybeFinishRecord();
+    void StartFreeze();
+    void StopFreeze();
+    void UpdateFreezeInput(CNetObj_PlayerInput *pInput);
+    void RenderFreezeIndicator();
+    void RenderAimLines();
 };
 
 #endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -73,7 +73,8 @@ CMenus::CMenus()
 	m_DemolistStorageType = IStorage::TYPE_ALL;
 
 	m_DemoPlayerState = DEMOPLAYER_NONE;
-	m_Dummy = false;
+        m_Dummy = false;
+        m_FujixPage = g_Config.m_UiFujixPage;
 
 	for(SUIAnimator &animator : m_aAnimatorsSettingsTab)
 	{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -767,7 +767,8 @@ public:
 	void DemolistPopulate();
 	void RefreshFilteredDemos();
 	void DemoSeekTick(IDemoPlayer::ETickOffset TickOffset);
-	bool m_Dummy;
+        bool m_Dummy;
+        int m_FujixPage;
 
 	const char *GetCurrentDemoFolder() const { return m_aCurrentDemoFolder; }
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3463,20 +3463,42 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 void CMenus::RenderSettingsFujix(CUIRect MainView)
 {
-       CUIRect RecordButton, PlayButton;
-       MainView.HSplitTop(10.0f, nullptr, &MainView);
-       MainView.HSplitTop(ms_ButtonHeight, &RecordButton, &MainView);
-       MainView.HSplitTop(5.0f, nullptr, &MainView);
-       MainView.HSplitTop(ms_ButtonHeight, &PlayButton, &MainView);
+    CUIRect TabBar, TasTab, FreezeTab, AimTab;
+    MainView.HSplitTop(20.0f, &TabBar, &MainView);
+    TabBar.VSplitLeft(TabBar.w / 3, &TasTab, &TabBar);
+    TabBar.VSplitLeft(TabBar.w / 2, &FreezeTab, &AimTab);
 
-       static CButtonContainer s_RecordBtn, s_PlayBtn;
+    static CButtonContainer s_TasBtn, s_FreezeBtn, s_AimBtn;
+    if(DoButton_MenuTab(&s_TasBtn, Localize("TAS"), m_FujixPage == 0, &TasTab, IGraphics::CORNER_L))
+            m_FujixPage = 0;
+    if(DoButton_MenuTab(&s_FreezeBtn, Localize("Freeze"), m_FujixPage == 1, &FreezeTab, 0))
+            m_FujixPage = 1;
+    if(DoButton_MenuTab(&s_AimBtn, Localize("Aim"), m_FujixPage == 2, &AimTab, IGraphics::CORNER_R))
+            m_FujixPage = 2;
+
+       g_Config.m_UiFujixPage = m_FujixPage;
+       MainView.HSplitTop(10.0f, nullptr, &MainView);
+
+       if(m_FujixPage == 0)
+       {
+               CUIRect RecordButton, PlayButton, TestButton;
+               MainView.HSplitTop(ms_ButtonHeight, &RecordButton, &MainView);
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &PlayButton, &MainView);
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &TestButton, &MainView);
+
+       static CButtonContainer s_RecordBtn, s_PlayBtn, s_TestBtn;
        const char *pRecLabel = GameClient()->m_FujixTas.IsRecording() ? Localize("Stop") : Localize("Record");
        const char *pPlayLabel = GameClient()->m_FujixTas.IsPlaying() ? Localize("Stop") : Localize("Play");
+       const char *pTestLabel = GameClient()->m_FujixTas.IsTesting() ? Localize("Stop") : Localize("Play (test)");
 
        if(DoButton_Menu(&s_RecordBtn, pRecLabel, 0, &RecordButton))
                Console()->ExecuteLine("fujix_record");
        if(DoButton_Menu(&s_PlayBtn, pPlayLabel, 0, &PlayButton))
                Console()->ExecuteLine("fujix_play");
+       if(DoButton_Menu(&s_TestBtn, pTestLabel, 0, &TestButton))
+               Console()->ExecuteLine("fujix_test");
 
        CUIRect RewindBox, TicksBox;
        MainView.HSplitTop(5.0f, nullptr, &MainView);
@@ -3508,6 +3530,64 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
        char aPreviewBuf[64];
        str_format(aPreviewBuf, sizeof(aPreviewBuf), Localize("Preview ticks: %d"), g_Config.m_ClFujixTasPreviewTicks);
        Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasPreviewTicks, &g_Config.m_ClFujixTasPreviewTicks, &PreviewBox, aPreviewBuf, 0, 200);
+
+       CUIRect ShowPlayersBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &ShowPlayersBox, &MainView);
+       static int s_ShowPlayersChk = 0;
+       if(DoButton_CheckBox(&s_ShowPlayersChk, Localize("Show players"), g_Config.m_ClFujixTasShowPlayers, &ShowPlayersBox))
+               g_Config.m_ClFujixTasShowPlayers ^= 1;
+
+       CUIRect RouteBox;
+       MainView.HSplitTop(5.0f, nullptr, &MainView);
+       MainView.HSplitTop(ms_ButtonHeight, &RouteBox, &MainView);
+       char aRouteBuf[64];
+       str_format(aRouteBuf, sizeof(aRouteBuf), Localize("Route ticks: %d"), g_Config.m_ClFujixTasRouteTicks);
+       Ui()->DoScrollbarOption(&g_Config.m_ClFujixTasRouteTicks, &g_Config.m_ClFujixTasRouteTicks, &RouteBox, aRouteBuf, 0, 200);
+       }
+       else if(m_FujixPage == 1)
+       {
+               CUIRect EnableBox, LevelBox, AdjustBox, UpBtn, DownBtn;
+               MainView.HSplitTop(ms_ButtonHeight, &EnableBox, &MainView);
+               static int s_EnableChk = 0;
+               if(DoButton_CheckBox(&s_EnableChk, Localize("Enable freeze"), g_Config.m_ClFujixFreeze, &EnableBox))
+                       g_Config.m_ClFujixFreeze ^= 1;
+
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &LevelBox, &MainView);
+               char aLevBuf[64];
+               str_format(aLevBuf, sizeof(aLevBuf), Localize("Freeze level: %d"), g_Config.m_ClFujixFreezeLevel);
+               Ui()->DoScrollbarOption(&g_Config.m_ClFujixFreezeLevel, &g_Config.m_ClFujixFreezeLevel, &LevelBox, aLevBuf, -10000, 10000);
+
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &AdjustBox, &MainView);
+               AdjustBox.VSplitMid(&UpBtn, &DownBtn);
+               static CButtonContainer s_UpBtn, s_DownBtn;
+               if(DoButton_Menu(&s_UpBtn, Localize("Up"), 0, &UpBtn))
+                       g_Config.m_ClFujixFreezeLevel -= 32;
+               if(DoButton_Menu(&s_DownBtn, Localize("Down"), 0, &DownBtn))
+                       g_Config.m_ClFujixFreezeLevel += 32;
+       }
+       else
+       {
+               CUIRect EnableBox, AngleBox, DrawBox;
+               MainView.HSplitTop(ms_ButtonHeight, &EnableBox, &MainView);
+               static int s_AimChk = 0;
+               if(DoButton_CheckBox(&s_AimChk, Localize("Enable aimbot"), g_Config.m_ClFujixAimbot, &EnableBox))
+                       g_Config.m_ClFujixAimbot ^= 1;
+
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &AngleBox, &MainView);
+               char aAngBuf[64];
+               str_format(aAngBuf, sizeof(aAngBuf), Localize("Angle range: %d"), g_Config.m_ClFujixAimAngle);
+               Ui()->DoScrollbarOption(&g_Config.m_ClFujixAimAngle, &g_Config.m_ClFujixAimAngle, &AngleBox, aAngBuf, 1, 180);
+
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &DrawBox, &MainView);
+               static int s_DrawChk = 0;
+               if(DoButton_CheckBox(&s_DrawChk, Localize("Show lines"), g_Config.m_ClFujixAimLines, &DrawBox))
+                       g_Config.m_ClFujixAimLines ^= 1;
+       }
 }
 
 CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect View, bool Active)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -187,8 +187,9 @@ void CGameClient::OnConsoleInit()
 
 	// register game commands to allow the client prediction to load settings from the map
 	Console()->Register("tune", "s[tuning] ?f[value]", CFGFLAG_GAME, ConTuneParam, this, "Tune variable to value");
-	Console()->Register("tune_zone", "i[zone] s[tuning] f[value]", CFGFLAG_GAME, ConTuneZone, this, "Tune in zone a variable to value");
-	Console()->Register("mapbug", "s[mapbug]", CFGFLAG_GAME, ConMapbug, this, "Enable map compatibility mode using the specified bug (example: grenade-doubleexplosion@ddnet.tw)");
+        Console()->Register("tune_zone", "i[zone] s[tuning] f[value]", CFGFLAG_GAME, ConTuneZone, this, "Tune in zone a variable to value");
+        Console()->Register("mapbug", "s[mapbug]", CFGFLAG_GAME, ConMapbug, this, "Enable map compatibility mode using the specified bug (example: grenade-doubleexplosion@ddnet.tw)");
+       Console()->Register("+click_d", "", CFGFLAG_CLIENT, ConDummyClick, this, "Dummy hammer toward player while held");
 
 	for(auto &pComponent : m_vpAll)
 		pComponent->m_pClient = this;
@@ -484,11 +485,29 @@ void CGameClient::OnUpdate()
 		}
 	});
 
-	if(g_Config.m_ClSubTickAiming && m_Binds.m_MouseOnAction)
-	{
-		m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy];
-		m_Binds.m_MouseOnAction = false;
-	}
+        if(g_Config.m_ClSubTickAiming && m_Binds.m_MouseOnAction)
+        {
+                m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy];
+                m_Binds.m_MouseOnAction = false;
+        }
+
+       if(g_Config.m_ClFujixDeepfly && Client()->DummyConnected())
+       {
+               vec2 DummyPos = m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+               bool HasAbove = false;
+               for(int i = 0; i < MAX_CLIENTS; i++)
+               {
+                       if(i == m_aLocalIds[!g_Config.m_ClDummy] || !m_aClients[i].m_Active)
+                               continue;
+                       vec2 Pos = m_aClients[i].m_Predicted.m_Pos;
+                       if(fabs(Pos.x - DummyPos.x) < 48 && Pos.y < DummyPos.y && DummyPos.y - Pos.y < 96)
+                       {
+                               HasAbove = true;
+                               break;
+                       }
+               }
+               g_Config.m_ClDummyHammer = HasAbove ? 1 : 0;
+       }
 
 	for(auto &pComponent : m_vpAll)
 	{
@@ -537,10 +556,120 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
                              return sizeof(NullInput);
                      }
 
-                       m_FujixTas.RecordInput(&LocalInput, Tick);
-                       m_FujixTas.MaybeFinishRecord();
-                       mem_copy(pData, &LocalInput, sizeof(LocalInput));
-                       return Size;
+                      m_FujixTas.RecordInput(&LocalInput, Tick);
+                      m_FujixTas.MaybeFinishRecord();
+                      m_FujixTas.UpdateFreezeInput(&LocalInput);
+
+                   if(g_Config.m_ClFujixDeepfly && Client()->DummyConnected())
+                   {
+                           int DummyID = m_aLocalIds[!g_Config.m_ClDummy];
+                           vec2 DummyPos = m_aClients[DummyID].m_Predicted.m_Pos;
+                           const CTuningParams *pTuning = GetTuning(g_Config.m_ClDummy);
+
+                           bool Hooked = m_PredictedChar.m_HookState == HOOK_GRABBED &&
+                                         m_PredictedChar.HookedPlayer() == DummyID;
+
+                           if(Hooked)
+                           {
+                                   if(m_DeepflyTick > 0)
+                                   {
+                                           LocalInput.m_Hook = 1;
+                                           m_DeepflyTick--;
+                                   }
+                                   else if(m_DeepflyCooldown > 0)
+                                   {
+                                           LocalInput.m_Hook = 0;
+                                           m_DeepflyCooldown--;
+                                   }
+                                   else
+                                   {
+                                           m_DeepflyTick = g_Config.m_ClFujixDeepflyHoldTicks - 1;
+                                           m_DeepflyCooldown = g_Config.m_ClFujixDeepflyReleaseTicks;
+                                           LocalInput.m_Hook = 1;
+                                   }
+                           }
+                           else
+                           {
+                                   m_DeepflyTick = 0;
+                                   m_DeepflyCooldown = 0;
+                                   if(DummyPos.y > m_LocalCharacterPos.y &&
+                                      fabs(DummyPos.x - m_LocalCharacterPos.x) < 48 &&
+                                      DummyPos.y - m_LocalCharacterPos.y < pTuning->m_HookLength)
+                                   {
+                                           LocalInput.m_Hook = 1;
+                                           vec2 Dir = DummyPos - m_LocalCharacterPos;
+                                           if(length(Dir) > 0.0f)
+                                           {
+                                                   Dir = normalize(Dir) * pTuning->m_HookLength;
+                                                   LocalInput.m_TargetX = (int)(Dir.x * 256);
+                                                   LocalInput.m_TargetY = (int)(Dir.y * 256);
+                                           }
+                                   }
+                           }
+                   }
+
+                     if(g_Config.m_ClFujixAimbot && LocalInput.m_Hook)
+                     {
+                             const CTuningParams *pTuning = GetTuning(g_Config.m_ClDummy);
+                             float BestDist = pTuning->m_HookLength;
+                             int BestID = -1;
+                             vec2 BestDir;
+
+                             vec2 AimDir = m_Controls.m_aMousePos[g_Config.m_ClDummy];
+                             if(length(AimDir) == 0.0f)
+                                     AimDir = vec2(1, 0);
+                             AimDir = normalize(AimDir);
+                             float AimAngle = angle(AimDir);
+                             float Limit = g_Config.m_ClFujixAimAngle * pi / 180.0f;
+
+                             for(int i = 0; i < MAX_CLIENTS; i++)
+                             {
+                                     if(!m_aClients[i].m_Active || i == m_Snap.m_LocalClientId)
+                                             continue;
+                                     vec2 Pos = m_aClients[i].m_Predicted.m_Pos;
+                                     vec2 Diff = Pos - m_LocalCharacterPos;
+                                     float Dist = length(Diff);
+                                     if(Dist > pTuning->m_HookLength)
+                                             continue;
+                                     float Ang = angle(normalize(Diff));
+                                     float Delta = absolute(AimAngle - Ang);
+                                     if(Delta > pi)
+                                             Delta = 2 * pi - Delta;
+                                     if(Delta <= Limit && Dist < BestDist)
+                                     {
+                                             BestDist = Dist;
+                                             BestID = i;
+                                             BestDir = Diff;
+                                     }
+                             }
+
+                             if(BestID < 0)
+                             {
+                                     for(int i = 0; i < MAX_CLIENTS; i++)
+                                     {
+                                             if(!m_aClients[i].m_Active || i == m_Snap.m_LocalClientId)
+                                                     continue;
+                                             vec2 Diff = m_aClients[i].m_Predicted.m_Pos - m_LocalCharacterPos;
+                                             float Dist = length(Diff);
+                                             if(Dist < BestDist)
+                                             {
+                                                     BestDist = Dist;
+                                                     BestID = i;
+                                                     BestDir = Diff;
+                                             }
+                                     }
+                             }
+
+                             if(BestID >= 0)
+                             {
+                                     vec2 Dir = normalize(BestDir) * pTuning->m_HookLength;
+                                     LocalInput.m_TargetX = (int)(Dir.x * 256);
+                                     LocalInput.m_TargetY = (int)(Dir.y * 256);
+                             }
+                     }
+
+                      mem_copy(pData, &LocalInput, sizeof(LocalInput));
+                      return Size;
                }
 
                if(m_FujixTas.IsRecording())
@@ -559,13 +688,36 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 		return 0;
 	}
 
-	if(!g_Config.m_ClDummyHammer)
-	{
-		if(m_DummyFire != 0)
-		{
-			m_DummyInput.m_Fire = (m_HammerInput.m_Fire + 1) & ~1;
-			m_DummyFire = 0;
-		}
+        if(!g_Config.m_ClDummyHammer)
+        {
+               if(m_DummyAutoClick)
+               {
+                        if(m_DummyAutoTick % 5 == 0)
+                                m_DummyInput.m_Fire = 1;
+                        else
+                                m_DummyInput.m_Fire = 0;
+                        m_DummyInput.m_WantedWeapon = WEAPON_HAMMER + 1;
+                        vec2 Dir = m_LocalCharacterPos - m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+                        if(length(Dir) > 0.0f)
+                        {
+                                Dir = normalize(Dir);
+                                Dir *= GetTuning(g_Config.m_ClDummy)->m_HookLength;
+                                m_DummyInput.m_TargetX = (int)(Dir.x * 256);
+                                m_DummyInput.m_TargetY = (int)(Dir.y * 256);
+                        }
+                        m_DummyAutoTick++;
+               }
+               else
+               {
+                        m_DummyAutoTick = 0;
+                        m_DummyInput.m_Fire = 0;
+               }
+
+                if(m_DummyFire != 0)
+                {
+                        m_DummyInput.m_Fire = (m_HammerInput.m_Fire + 1) & ~1;
+                        m_DummyFire = 0;
+                }
 
 		if(!Force && (!m_DummyInput.m_Direction && !m_DummyInput.m_Jump && !m_DummyInput.m_Hook))
 		{
@@ -700,10 +852,14 @@ void CGameClient::OnReset()
 
 	m_NextChangeInfo = 0;
 	std::fill(std::begin(m_aLocalIds), std::end(m_aLocalIds), -1);
-	m_DummyInput = {};
-	m_HammerInput = {};
-	m_DummyFire = 0;
-	m_ReceivedDDNetPlayer = false;
+       m_DummyInput = {};
+       m_HammerInput = {};
+       m_DummyFire = 0;
+       m_DummyAutoClick = false;
+       m_DummyAutoTick = 0;
+       m_DeepflyTick = 0;
+       m_DeepflyCooldown = 0;
+       m_ReceivedDDNetPlayer = false;
 
 	m_Teams.Reset();
 	m_GameWorld.Clear();
@@ -4435,6 +4591,14 @@ void CGameClient::ConMapbug(IConsole::IResult *pResult, void *pUserData)
 	default:
 		dbg_assert(false, "unreachable");
 	}
+}
+
+void CGameClient::ConDummyClick(IConsole::IResult *pResult, void *pUserData)
+{
+    CGameClient *pSelf = static_cast<CGameClient *>(pUserData);
+    pSelf->m_DummyAutoClick = pResult->GetInteger(0) != 0;
+    if(!pSelf->m_DummyAutoClick)
+        pSelf->m_DummyAutoTick = 0;
 }
 
 void CGameClient::ConchainMenuMap(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -240,7 +240,8 @@ private:
 
 	static void ConTuneParam(IConsole::IResult *pResult, void *pUserData);
 	static void ConTuneZone(IConsole::IResult *pResult, void *pUserData);
-	static void ConMapbug(IConsole::IResult *pResult, void *pUserData);
+       static void ConMapbug(IConsole::IResult *pResult, void *pUserData);
+       static void ConDummyClick(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConchainMenuMap(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
@@ -641,9 +642,13 @@ public:
 
 	int m_aLocalIds[NUM_DUMMIES];
 	CNetObj_PlayerInput m_DummyInput;
-	CNetObj_PlayerInput m_HammerInput;
-	unsigned int m_DummyFire;
-	bool m_ReceivedDDNetPlayer;
+       CNetObj_PlayerInput m_HammerInput;
+       unsigned int m_DummyFire;
+       bool m_DummyAutoClick;
+       int m_DummyAutoTick;
+       int m_DeepflyTick;
+       int m_DeepflyCooldown;
+       bool m_ReceivedDDNetPlayer;
 
 	class CTeamsCore m_Teams;
 


### PR DESCRIPTION
## Summary
- add config options for deepfly hold and release ticks
- adjust deepfly hook cycle to use these timings

## Testing
- `cargo test --locked` *(fails: environment variable `DDNET_TEST_LIBRARIES` required but not found)*
- `cmake -B build -GNinja` *(fails: glslangValidator binary was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684650826f88832c9680127a3421b491