### PR TITLE
Add Fujix AI toggle and menu

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -694,6 +694,8 @@ MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_S
 
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, -1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unpredicted shadow tee (0 = off, 1 = on, -1 = don't even show in debug mode)")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
+MACRO_CONFIG_INT(ClFujixAi, cl_fujix_ai, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable Fujix AI to avoid freeze")
+MACRO_CONFIG_INT(ClFujixAiTicks, cl_fujix_ai_ticks, 9, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Base prediction ticks for Fujix AI")
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ninja skin")
 MACRO_CONFIG_INT(ClShowHookCollOther, cl_show_hook_coll_other, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision line (2 to always show)")
 MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own players' hook collision line (2 to always show)")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -278,10 +278,10 @@ int CControls::SnapInput(int *pData)
 
 		// stress testing
 #ifdef CONF_DEBUG
-		if(g_Config.m_DbgStress)
-		{
-			float t = Client()->LocalTime();
-			mem_zero(&m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
+                if(g_Config.m_DbgStress)
+                {
+                        float t = Client()->LocalTime();
+                        mem_zero(&m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
 
 			m_aInputData[g_Config.m_ClDummy].m_Direction = ((int)t / 2) & 1;
 			m_aInputData[g_Config.m_ClDummy].m_Jump = ((int)t);
@@ -289,10 +289,11 @@ int CControls::SnapInput(int *pData)
 			m_aInputData[g_Config.m_ClDummy].m_Hook = ((int)(t * 2)) & 1;
 			m_aInputData[g_Config.m_ClDummy].m_WantedWeapon = ((int)t) % NUM_WEAPONS;
 			m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)(std::sin(t * 3) * 100.0f);
-			m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)(std::cos(t * 3) * 100.0f);
-		}
+                        m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)(std::cos(t * 3) * 100.0f);
+                }
 #endif
-		// check if we need to send input
+               GameClient()->FujixAI(&m_aInputData[g_Config.m_ClDummy]);
+                // check if we need to send input
 		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Direction != m_aLastData[g_Config.m_ClDummy].m_Direction;
 		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Jump != m_aLastData[g_Config.m_ClDummy].m_Jump;
 		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Fire != m_aLastData[g_Config.m_ClDummy].m_Fire;

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -31,8 +31,9 @@ enum
 	ASSETS_TAB_EMOTICONS = 2,
 	ASSETS_TAB_PARTICLES = 3,
 	ASSETS_TAB_HUD = 4,
-	ASSETS_TAB_EXTRAS = 5,
-	NUMBER_OF_ASSETS_TABS = 6,
+        ASSETS_TAB_EXTRAS = 5,
+       ASSETS_TAB_FUJIX = 6,
+       NUMBER_OF_ASSETS_TABS = 7,
 };
 
 void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
@@ -352,14 +353,15 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	const float TabWidth = TabBar.w / NUMBER_OF_ASSETS_TABS;
-	static CButtonContainer s_aPageTabs[NUMBER_OF_ASSETS_TABS] = {};
-	const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
-		Localize("Entities"),
-		Localize("Game"),
-		Localize("Emoticons"),
-		Localize("Particles"),
-		Localize("HUD"),
-		Localize("Extras")};
+       static CButtonContainer s_aPageTabs[NUMBER_OF_ASSETS_TABS] = {};
+       const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
+               Localize("Entities"),
+               Localize("Game"),
+               Localize("Emoticons"),
+               Localize("Particles"),
+               Localize("HUD"),
+               Localize("Extras"),
+               "FUJIX"};
 
 	for(int Tab = ASSETS_TAB_ENTITIES; Tab < NUMBER_OF_ASSETS_TABS; ++Tab)
 	{
@@ -372,16 +374,29 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		}
 	}
 
-	auto LoadStartTime = time_get_nanoseconds();
-	SMenuAssetScanUser User;
-	User.m_pUser = this;
-	User.m_LoadedFunc = [&]() {
-		if(time_get_nanoseconds() - LoadStartTime > 500ms)
-			RenderLoading(Localize("Loading assets"), "", 0);
-	};
-	if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
-	{
-		if(m_vEntitiesList.empty())
+       auto LoadStartTime = time_get_nanoseconds();
+       SMenuAssetScanUser User;
+       User.m_pUser = this;
+       User.m_LoadedFunc = [&]() {
+               if(time_get_nanoseconds() - LoadStartTime > 500ms)
+                       RenderLoading(Localize("Loading assets"), "", 0);
+       };
+       if(s_CurCustomTab == ASSETS_TAB_FUJIX)
+       {
+               CUIRect Button;
+               MainView.HSplitTop(10.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &Button, &MainView);
+               static CButtonContainer s_FujixButton;
+               if(DoButton_CheckBox(&s_FujixButton, "Enable Fujix AI", g_Config.m_ClFujixAi, &Button))
+                       g_Config.m_ClFujixAi ^= 1;
+               MainView.HSplitTop(5.0f, nullptr, &MainView);
+               MainView.HSplitTop(ms_ButtonHeight, &Button, &MainView);
+               Ui()->DoScrollbarOption(&g_Config.m_ClFujixAiTicks, &g_Config.m_ClFujixAiTicks, &Button, "Prediction ticks", 1, 20);
+               return;
+       }
+       if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
+       {
+               if(m_vEntitiesList.empty())
 		{
 			SCustomEntities EntitiesItem;
 			str_copy(EntitiesItem.m_aName, "default");

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4862,14 +4862,16 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
        pInput->m_Jump = 0;
 
        vec2 BestPos = Start;
-       float BestDist = 1e9f;
+       float BestScore = 1e9f;
 
-       int AngleStart = FallingHazard ? -90 : 0;
-       int AngleEnd = FallingHazard ? 90 : 360;
-       for(int Angle = AngleStart; Angle < AngleEnd; Angle += 15)
+       float HookLen = m_aTuning[g_Config.m_ClDummy].m_HookLength;
+       float AngleStart = FallingHazard ? -150.0f : -120.0f;
+       float AngleEnd = FallingHazard ? -30.0f : 120.0f;
+
+       for(float Angle = AngleStart; Angle <= AngleEnd; Angle += 15.0f)
        {
-               vec2 Dir = vec2(std::cos((float)Angle * pi / 180.0f), std::sin((float)Angle * pi / 180.0f));
-               vec2 End = Start + Dir * m_aTuning[g_Config.m_ClDummy].m_HookLength;
+               vec2 Dir = direction(Angle * pi / 180.0f);
+               vec2 End = Start + Dir * HookLen;
                vec2 Pos;
                if(Collision()->IntersectLine(Start, End, &Pos, nullptr))
                {
@@ -4877,19 +4879,23 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
                        int Tile = Collision()->GetTileIndex(Index);
                        int Front = Collision()->GetFrontTileIndex(Index);
                        int Switch = Collision()->GetSwitchType(Index);
-                       if(!IsFreeze(Tile) && !IsFreeze(Front) && !IsFreeze(Switch))
+
+                       if(IsFreeze(Tile) || IsFreeze(Front) || IsFreeze(Switch))
+                               continue;
+
+                       if(FallingHazard && Pos.y > Start.y)
+                               continue;
+
+                       float Score = FallingHazard ? Pos.y : distance(Pos, HazardPos);
+                       if(Score < BestScore)
                        {
-                               float Dist = distance(Pos, Core.m_Pos);
-                               if(Dist < BestDist)
-                               {
-                                       BestDist = Dist;
-                                       BestPos = Pos;
-                               }
+                               BestScore = Score;
+                               BestPos = Pos;
                        }
                }
        }
 
-       if(BestDist < 1e9f)
+       if(BestScore < 1e9f)
        {
                pInput->m_Hook = 1;
                m_Controls.m_aMousePos[g_Config.m_ClDummy] = BestPos - m_LocalCharacterPos;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4878,7 +4878,9 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
        if(BestDist < 1e9f)
        {
                pInput->m_Hook = 1;
-               m_CursorPos[g_Config.m_ClDummy] = BestPos;
+               m_Controls.m_aMousePos[g_Config.m_ClDummy] = BestPos - m_LocalCharacterPos;
+               pInput->m_TargetX = (int)m_Controls.m_aMousePos[g_Config.m_ClDummy].x;
+               pInput->m_TargetY = (int)m_Controls.m_aMousePos[g_Config.m_ClDummy].y;
        }
        else
        {

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4785,12 +4785,105 @@ void CGameClient::CleanMultiViewIds()
 
 void CGameClient::CleanMultiViewId(int ClientId)
 {
-	if(ClientId >= MAX_CLIENTS || ClientId < 0)
-		return;
+        if(ClientId >= MAX_CLIENTS || ClientId < 0)
+                return;
 
 	m_aMultiViewId[ClientId] = false;
 	m_MultiView.m_aLastFreeze[ClientId] = 0.0f;
-	m_MultiView.m_aVanish[ClientId] = false;
+        m_MultiView.m_aVanish[ClientId] = false;
+}
+
+void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
+{
+       if(!g_Config.m_ClFujixAi || !m_Snap.m_pLocalCharacter)
+               return;
+
+       auto IsFreeze = [](int Tile) {
+               return Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE;
+       };
+
+       int BaseTicks = g_Config.m_ClFujixAiTicks;
+       int ExtraTicks = clamp((int)(length(m_PredictedChar.m_Vel) / 50.0f), 0, 10);
+       int PredictTicks = clamp(BaseTicks + ExtraTicks, 1, 20);
+
+       CCharacterCore Core = m_PredictedChar;
+       bool Hazard = false;
+       for(int Step = 0; Step < PredictTicks; ++Step)
+       {
+               Core.Tick(false);
+               Core.Move();
+               Core.Quantize();
+
+               int Index = Collision()->GetPureMapIndex(Core.m_Pos);
+               int Tile = Collision()->GetTileIndex(Index);
+               int Front = Collision()->GetFrontTileIndex(Index);
+               int Switch = Collision()->GetSwitchType(Index);
+
+               if(IsFreeze(Tile) || IsFreeze(Front) || IsFreeze(Switch))
+               {
+                       Hazard = true;
+                       break;
+               }
+
+               int FutureTick = (Client()->GameTick(g_Config.m_ClDummy) + Step) % 200;
+               for(int i = 0; i < MAX_CLIENTS && !Hazard; ++i)
+               {
+                       if(i == m_Snap.m_LocalClientId || !m_aClients[i].m_Active)
+                               continue;
+                       if(m_aClients[i].m_aPredTick[FutureTick] != Client()->GameTick(g_Config.m_ClDummy) + Step)
+                               continue;
+                       if(distance(m_aClients[i].m_aPredPos[FutureTick], Core.m_Pos) < 32.0f)
+                       {
+                               Hazard = true;
+                               break;
+                       }
+               }
+               if(Hazard)
+                       break;
+       }
+
+       if(!Hazard)
+               return;
+
+       pInput->m_Direction = 0;
+       pInput->m_Jump = 0;
+
+       vec2 Start = m_PredictedChar.m_Pos;
+       vec2 BestPos = Start;
+       float BestDist = 1e9f;
+
+       for(int Angle = 0; Angle < 360; Angle += 20)
+       {
+               vec2 Dir = vec2(std::cos((float)Angle * pi / 180.0f), std::sin((float)Angle * pi / 180.0f));
+               vec2 End = Start + Dir * m_aTuning[g_Config.m_ClDummy].m_HookLength;
+               vec2 Pos;
+               if(!Collision()->IntersectLine(Start, End, &Pos, nullptr))
+               {
+                       int Index = Collision()->GetPureMapIndex(Pos);
+                       int Tile = Collision()->GetTileIndex(Index);
+                       int Front = Collision()->GetFrontTileIndex(Index);
+                       int Switch = Collision()->GetSwitchType(Index);
+                       if(!IsFreeze(Tile) && !IsFreeze(Front) && !IsFreeze(Switch))
+                       {
+                               float Dist = distance(Pos, Core.m_Pos);
+                               if(Dist < BestDist)
+                               {
+                                       BestDist = Dist;
+                                       BestPos = Pos;
+                               }
+                       }
+               }
+       }
+
+       if(BestDist < 1e9f)
+       {
+               pInput->m_Hook = 1;
+               m_CursorPos[g_Config.m_ClDummy] = BestPos;
+       }
+       else
+       {
+               pInput->m_Hook = 0;
+       }
 }
 
 bool CGameClient::IsMultiViewIdSet()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4808,6 +4808,8 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
 
        CCharacterCore Core = m_PredictedChar;
        bool Hazard = false;
+       int HazardStep = -1;
+       vec2 HazardPos = Core.m_Pos;
        for(int Step = 0; Step < PredictTicks; ++Step)
        {
                Core.Tick(false);
@@ -4822,6 +4824,8 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
                if(IsFreeze(Tile) || IsFreeze(Front) || IsFreeze(Switch))
                {
                        Hazard = true;
+                       HazardStep = Step;
+                       HazardPos = Core.m_Pos;
                        break;
                }
 
@@ -4835,6 +4839,8 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
                        if(distance(m_aClients[i].m_aPredPos[FutureTick], Core.m_Pos) < 32.0f)
                        {
                                Hazard = true;
+                               HazardStep = Step;
+                               HazardPos = Core.m_Pos;
                                break;
                        }
                }
@@ -4845,19 +4851,27 @@ void CGameClient::FujixAI(CNetObj_PlayerInput *pInput)
        if(!Hazard)
                return;
 
-       pInput->m_Direction = 0;
+       vec2 Start = m_PredictedChar.m_Pos;
+       bool FallingHazard = HazardPos.y > Start.y + 2.0f;
+
+       if(!FallingHazard && HazardStep > 2)
+       {
+               pInput->m_Direction = 0;
+       }
+
        pInput->m_Jump = 0;
 
-       vec2 Start = m_PredictedChar.m_Pos;
        vec2 BestPos = Start;
        float BestDist = 1e9f;
 
-       for(int Angle = 0; Angle < 360; Angle += 20)
+       int AngleStart = FallingHazard ? -90 : 0;
+       int AngleEnd = FallingHazard ? 90 : 360;
+       for(int Angle = AngleStart; Angle < AngleEnd; Angle += 15)
        {
                vec2 Dir = vec2(std::cos((float)Angle * pi / 180.0f), std::sin((float)Angle * pi / 180.0f));
                vec2 End = Start + Dir * m_aTuning[g_Config.m_ClDummy].m_HookLength;
                vec2 Pos;
-               if(!Collision()->IntersectLine(Start, End, &Pos, nullptr))
+               if(Collision()->IntersectLine(Start, End, &Pos, nullptr))
                {
                        int Index = Collision()->GetPureMapIndex(Pos);
                        int Tile = Collision()->GetTileIndex(Index);

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -855,9 +855,10 @@ public:
 	bool m_MultiViewActivated;
 	bool m_aMultiViewId[MAX_CLIENTS];
 
-	void ResetMultiView();
-	int FindFirstMultiViewId();
-	void CleanMultiViewId(int ClientId);
+       void ResetMultiView();
+       int FindFirstMultiViewId();
+       void CleanMultiViewId(int ClientId);
+       void FujixAI(CNetObj_PlayerInput *pInput);
 
 private:
 	std::vector<CSnapEntities> m_vSnapEntities;
@@ -869,8 +870,8 @@ private:
 	std::vector<std::shared_ptr<CManagedTeeRenderInfo>> m_vpManagedTeeRenderInfos;
 	void UpdateManagedTeeRenderInfos();
 
-	void UpdatePrediction();
-	void UpdateSpectatorCursor();
+       void UpdatePrediction();
+       void UpdateSpectatorCursor();
 	void UpdateRenderedCharacters();
 
 	int m_aLastUpdateTick[MAX_CLIENTS] = {0};


### PR DESCRIPTION
## Summary
- add `cl_fujix_ai` client config
- create "FUJIX" assets tab with enable button
- implement simple freeze avoidance AI
- expose FujixAI helper publicly for controls
- added adaptive prediction and hooking improvements

## Testing
- `scripts/fix_style.py` *(fails: Found no clang-format 10)*
- `cmake -Bbuild -GNinja` *(fails: glslangValidator and other deps missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b43636ce0832cbf1086cfd597ca9e