### PR TITLE
Fix Block freeze legit toggle

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3553,7 +3553,8 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
            BlockBox.VSplitLeft(BlockBox.h, &Icon, &BlockBox);
            Ui()->DoLabel(&Icon, FONT_ICON_LOCK, BlockBox.h * 0.7f, TEXTALIGN_MC);
            static int s_BlockChk = 0;
-           DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox);
+           if(DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox))
+                   g_Config.m_ClFujixBlockFreezeLegit ^= 1;
 
            MainView.HSplitTop(5.0f, nullptr, &MainView);
            CUIRect RageBox;


### PR DESCRIPTION
## Summary
- allow toggling "Block freeze (legit)" in the Fujix menu

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: glslangValidator binary was not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3e7d3eb0832c9fba0ba1c90ecb8c