### PR TITLE
Fix Block freeze legit toggle

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -141,8 +141,53 @@ void CFujixTas::ApplyHookEvents(int PredTick, bool ToPhantom)
     }
 }
 
+void CFujixTas::AutoRescueHook(CNetObj_PlayerInput *pInput)
+{
+    if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter)
+        return;
+
+    if(pInput->m_Hook)
+        return;
+
+    auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
+        CCharacterCore Core = GameClient()->m_PredictedChar;
+        Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        const int Steps = 12;
+        for(int i = 0; i < Steps; i++)
+        {
+            CNetObj_PlayerInput Step = Input;
+            Core.m_Input = Step;
+            Core.Tick(true);
+            Core.Move();
+            Core.Quantize();
+            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
+            int Tile = Collision()->GetTileIndex(Index);
+            int Front = Collision()->GetFrontTileIndex(Index);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return i + 1;
+        }
+        return 0;
+    };
+
+    if(!PredictFreeze(*pInput))
+        return;
+
+    CNetObj_PlayerInput Hooked = *pInput;
+    Hooked.m_Hook = 1;
+    vec2 Dir = vec2(Ui()->MouseWorldX(), Ui()->MouseWorldY()) - GameClient()->m_PredictedChar.m_Pos;
+    Hooked.m_TargetX = (int)(Dir.x * 256.0f);
+    Hooked.m_TargetY = (int)(Dir.y * 256.0f);
+
+    if(!PredictFreeze(Hooked))
+        *pInput = Hooked;
+}
+
 void CFujixTas::ApplyRageInput(CNetObj_PlayerInput *pInput)
 {
+    AutoRescueHook(pInput);
+
     if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter || !m_RageActive)
         return;
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -80,6 +80,7 @@ void RenderFuturePath(int TicksAhead);
 void TickPhantomUpTo(int TargetTick);
 void RecordHookState(int Tick);
 void ApplyHookEvents(int PredTick, bool ToPhantom);
+void AutoRescueHook(CNetObj_PlayerInput *pInput);
 public:
 void ApplyRageInput(CNetObj_PlayerInput *pInput);
 void UpdateRageTarget();

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3553,7 +3553,8 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
            BlockBox.VSplitLeft(BlockBox.h, &Icon, &BlockBox);
            Ui()->DoLabel(&Icon, FONT_ICON_LOCK, BlockBox.h * 0.7f, TEXTALIGN_MC);
            static int s_BlockChk = 0;
-           DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox);
+           if(DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox))
+                   g_Config.m_ClFujixBlockFreezeLegit ^= 1;
 
            MainView.HSplitTop(5.0f, nullptr, &MainView);
            CUIRect RageBox;


### PR DESCRIPTION
## Summary
- allow toggling "Block freeze (legit)" in the Fujix menu
- improve Block freeze rage to auto-hook when a freeze collision is predicted

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: missing Opus, Opusfile, SDL2, Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_687e3e7d3eb0832c9fba0ba1c90ecb8c