### PR TITLE
Remove freeze rage feature

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -662,6 +662,7 @@ MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200,
 MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
 MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 MACRO_CONFIG_INT(ClFujixBlockFreezeLegit, cl_fujix_block_freeze_legit, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prevent collisions with freeze tiles")
+MACRO_CONFIG_INT(ClFujixBlockFreezeRage, cl_fujix_block_freeze_rage, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Advanced autopilot freeze avoidance")
 MACRO_CONFIG_INT(ClFujixDeepfly, cl_fujix_deepfly, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable automatic hammerfly for dummy")
 MACRO_CONFIG_INT(ClFujixDeepflyHoldTicks, cl_fujix_deepfly_hold_ticks, 2, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to hold hook when deepfly")
 MACRO_CONFIG_INT(ClFujixDeepflyReleaseTicks, cl_fujix_deepfly_release_ticks, 1, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to release hook when deepfly")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -662,7 +662,6 @@ MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200,
 MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
 MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 MACRO_CONFIG_INT(ClFujixBlockFreezeLegit, cl_fujix_block_freeze_legit, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prevent collisions with freeze tiles")
-MACRO_CONFIG_INT(ClFujixBlockFreezeRage, cl_fujix_block_freeze_rage, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Autopilot movement to clicked location")
 MACRO_CONFIG_INT(ClFujixDeepfly, cl_fujix_deepfly, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable automatic hammerfly for dummy")
 MACRO_CONFIG_INT(ClFujixDeepflyHoldTicks, cl_fujix_deepfly_hold_ticks, 2, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to hold hook when deepfly")
 MACRO_CONFIG_INT(ClFujixDeepflyReleaseTicks, cl_fujix_deepfly_release_ticks, 1, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to release hook when deepfly")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -41,12 +41,8 @@ CFujixTas::CFujixTas()
     m_HookFile = nullptr;
     m_HookPlayIndex = 0;
 
-    m_RageActive = false;
     m_LastHookState = HOOK_RETRACTED;
     m_LastHookedPlayer = -1;
-    m_RageActive = false;
-    m_RageTarget = vec2(0.f, 0.f);
-    m_RagePrevEnabled = false;
 }
 
 int CFujixTas::Sizeof() const
@@ -141,68 +137,6 @@ void CFujixTas::ApplyHookEvents(int PredTick, bool ToPhantom)
     }
 }
 
-void CFujixTas::ApplyRageInput(CNetObj_PlayerInput *pInput)
-{
-    if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter || !m_RageActive)
-        return;
-
-    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
-    vec2 Diff = m_RageTarget - Pos;
-
-    if(length(Diff) < 2.0f)
-    {
-        pInput->m_Direction = 0;
-        pInput->m_Hook = 0;
-        pInput->m_Jump = 0;
-        m_RageActive = false;
-        return;
-    }
-
-    if(Diff.x > 2.0f)
-        pInput->m_Direction = 1;
-    else if(Diff.x < -2.0f)
-        pInput->m_Direction = -1;
-    else
-        pInput->m_Direction = 0;
-
-    if(Diff.y < -32.0f)
-        pInput->m_Jump = 1;
-
-    if(length(Diff) > 96.0f)
-    {
-        pInput->m_Hook = 1;
-        pInput->m_TargetX = (int)(Diff.x * 256.0f);
-        pInput->m_TargetY = (int)(Diff.y * 256.0f);
-    }
-    else
-    {
-        pInput->m_Hook = 0;
-    }
-}
-
-void CFujixTas::UpdateRageTarget()
-{
-    if(g_Config.m_ClFujixBlockFreezeRage != m_RagePrevEnabled)
-    {
-        m_RagePrevEnabled = g_Config.m_ClFujixBlockFreezeRage;
-        if(!m_RagePrevEnabled)
-            m_RageActive = false;
-        else
-        {
-            m_RageTarget = vec2(Ui()->MouseWorldX(), Ui()->MouseWorldY());
-            m_RageActive = true;
-        }
-    }
-
-    if(!g_Config.m_ClFujixBlockFreezeRage)
-        return;
-
-    if(Input()->KeyPress(KEY_MOUSE_1))
-    {
-        m_RageTarget = vec2(Ui()->MouseWorldX(), Ui()->MouseWorldY());
-        m_RageActive = true;
-    }
-}
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
 {
@@ -272,7 +206,6 @@ void CFujixTas::StartRecord()
     m_LastHookState = GameClient()->m_PredictedChar.m_HookState;
     m_LastHookedPlayer = GameClient()->m_PredictedChar.HookedPlayer();
 
-    m_RageActive = false;
 
     // initialize phantom to visualize recording
     if(GameClient()->m_Snap.m_LocalClientId >= 0)
@@ -487,7 +420,6 @@ void CFujixTas::StopPlay()
     m_vHookEvents.clear();
     m_HookPlayIndex = 0;
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
-    m_RageActive = false;
 }
 
 void CFujixTas::StartTest()
@@ -551,7 +483,6 @@ void CFujixTas::StopTest()
     m_vEntries.clear();
     m_vHookEvents.clear();
     m_HookPlayIndex = 0;
-    m_RageActive = false;
 }
 
 void CFujixTas::TickPhantomUpTo(int TargetTick)
@@ -629,7 +560,6 @@ void CFujixTas::OnUpdate()
         StopTest();
 
     MaybeFinishRecord();
-    UpdateRageTarget();
     RecordHookState(Client()->PredGameTick(g_Config.m_ClDummy));
     TickPhantom();
 }
@@ -730,6 +660,5 @@ void CFujixTas::OnMapLoad()
     if(m_Recording)
         FinishRecord();
     StopTest();
-    m_RageActive = false;
 
 }

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -43,6 +43,9 @@ CFujixTas::CFujixTas()
 
     m_LastHookState = HOOK_RETRACTED;
     m_LastHookedPlayer = -1;
+
+    m_RageActive = false;
+    m_RageTarget = vec2(0.f, 0.f);
 }
 
 int CFujixTas::Sizeof() const
@@ -363,6 +366,106 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
 void CFujixTas::UpdateFreezeInput(CNetObj_PlayerInput *pInput)
 {
     BlockFreezeInput(pInput);
+}
+
+void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
+{
+    if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter)
+        return;
+
+    auto PredictFreeze = [&](const CNetObj_PlayerInput &Input, int HookMode) {
+        CCharacterCore Core = GameClient()->m_PredictedChar;
+        Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        const int Steps = 12;
+        for(int i = 0; i < Steps; i++)
+        {
+            CNetObj_PlayerInput Step = Input;
+            if(HookMode == 0)
+                Step.m_Hook = 0;
+            else if(HookMode == 1)
+                Step.m_Hook = 1;
+            else if(HookMode == 2)
+                Step.m_Hook = i == 0 ? 1 : 0;
+            Core.m_Input = Step;
+            Core.Tick(true);
+            Core.Move();
+            Core.Quantize();
+            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
+            int Tile = Collision()->GetTileIndex(Index);
+            int Front = Collision()->GetFrontTileIndex(Index);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return i + 1;
+        }
+        return 0;
+    };
+
+    auto IsFreezeTile = [&](vec2 Pos) {
+        int Index = Collision()->GetPureMapIndex(Pos.x, Pos.y);
+        int Tile = Collision()->GetTileIndex(Index);
+        int Front = Collision()->GetFrontTileIndex(Index);
+        return Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+               Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+    };
+
+    if(!m_RageActive)
+    {
+        if(PredictFreeze(*pInput, -1))
+        {
+            vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+            float BestDist = 1e9f;
+            vec2 BestPos = Pos;
+            for(int y = -4; y <= 4; y++)
+            for(int x = -4; x <= 4; x++)
+            {
+                vec2 Candidate = Pos + vec2(x * 32.0f, y * 32.0f);
+                if(!IsFreezeTile(Candidate))
+                {
+                    float Dist = distance(Pos, Candidate);
+                    if(Dist < BestDist)
+                    {
+                        BestDist = Dist;
+                        BestPos = Candidate;
+                    }
+                }
+            }
+            m_RageTarget = BestPos;
+            m_RageActive = true;
+        }
+    }
+    else
+    {
+        if(distance(GameClient()->m_PredictedChar.m_Pos, m_RageTarget) < 2.0f)
+            m_RageActive = false;
+    }
+
+    if(!m_RageActive)
+        return;
+
+    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+    vec2 Diff = m_RageTarget - Pos;
+
+    if(Diff.x > 2.0f)
+        pInput->m_Direction = 1;
+    else if(Diff.x < -2.0f)
+        pInput->m_Direction = -1;
+    else
+        pInput->m_Direction = 0;
+
+    if(Diff.y < -32.0f)
+        pInput->m_Jump = 1;
+
+    if(length(Diff) > 96.0f)
+    {
+        pInput->m_Hook = 1;
+        pInput->m_TargetX = (int)(Diff.x * 256.0f);
+        pInput->m_TargetY = (int)(Diff.y * 256.0f);
+    }
+    else
+    {
+        pInput->m_Hook = 0;
+    }
 }
 
 void CFujixTas::StartPlay()

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -55,11 +55,6 @@ int m_HookPlayIndex;
 int m_LastHookState;
 int m_LastHookedPlayer;
 
-// Rage mode
-bool m_RageActive;
-vec2 m_RageTarget;
-bool m_RagePrevEnabled;
-
 // Phantom
 bool m_PhantomActive;
 int m_PhantomTick;
@@ -81,8 +76,6 @@ void TickPhantomUpTo(int TargetTick);
 void RecordHookState(int Tick);
 void ApplyHookEvents(int PredTick, bool ToPhantom);
 public:
-void ApplyRageInput(CNetObj_PlayerInput *pInput);
-void UpdateRageTarget();
 
 static void ConRecord(IConsole::IResult *pResult, void *pUserData);
 static void ConPlay(IConsole::IResult *pResult, void *pUserData);
@@ -112,7 +105,6 @@ void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
 void MaybeFinishRecord();
 void BlockFreezeInput(CNetObj_PlayerInput *pInput);
 void UpdateFreezeInput(CNetObj_PlayerInput *pInput); // legacy compatibility
-void SetRageTarget(vec2 Pos) { m_RageTarget = Pos; }
 };
 
 #endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -55,6 +55,10 @@ int m_HookPlayIndex;
 int m_LastHookState;
 int m_LastHookedPlayer;
 
+// Rage autopilot
+bool m_RageActive;
+vec2 m_RageTarget;
+
 // Phantom
 bool m_PhantomActive;
 int m_PhantomTick;
@@ -104,6 +108,7 @@ bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
 void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
 void MaybeFinishRecord();
 void BlockFreezeInput(CNetObj_PlayerInput *pInput);
+void BlockFreezeRageInput(CNetObj_PlayerInput *pInput);
 void UpdateFreezeInput(CNetObj_PlayerInput *pInput); // legacy compatibility
 };
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3553,8 +3553,14 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
            BlockBox.VSplitLeft(BlockBox.h, &Icon, &BlockBox);
            Ui()->DoLabel(&Icon, FONT_ICON_LOCK, BlockBox.h * 0.7f, TEXTALIGN_MC);
            static int s_BlockChk = 0;
-           if(DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox))
-                   g_Config.m_ClFujixBlockFreezeLegit ^= 1;
+           DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox);
+
+           MainView.HSplitTop(5.0f, nullptr, &MainView);
+           CUIRect RageBox;
+           MainView.HSplitTop(ms_ButtonHeight, &RageBox, &MainView);
+           static int s_RageChk = 0;
+           if(DoButton_CheckBox(&s_RageChk, Localize("Block freeze (rage)"), g_Config.m_ClFujixBlockFreezeRage, &RageBox))
+                   g_Config.m_ClFujixBlockFreezeRage ^= 1;
 
     }
        else if(m_FujixPage == 2)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3556,12 +3556,6 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
            if(DoButton_CheckBox(&s_BlockChk, Localize("Block freeze (legit)"), g_Config.m_ClFujixBlockFreezeLegit, &BlockBox))
                    g_Config.m_ClFujixBlockFreezeLegit ^= 1;
 
-           MainView.HSplitTop(5.0f, nullptr, &MainView);
-           CUIRect RageBox;
-           MainView.HSplitTop(ms_ButtonHeight, &RageBox, &MainView);
-           static int s_RageChk = 0;
-           if(DoButton_CheckBox(&s_RageChk, Localize("Block freeze (rage)"), g_Config.m_ClFujixBlockFreezeRage, &RageBox))
-                   g_Config.m_ClFujixBlockFreezeRage ^= 1;
     }
        else if(m_FujixPage == 2)
        {

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -548,6 +548,7 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
                if(Size > 0)
                {
                    m_FujixTas.BlockFreezeInput(&LocalInput);
+                   m_FujixTas.BlockFreezeRageInput(&LocalInput);
                    m_FujixTas.RecordInput(&LocalInput, Tick);
                    m_FujixTas.MaybeFinishRecord();
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -548,7 +548,6 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
                if(Size > 0)
                {
                    m_FujixTas.BlockFreezeInput(&LocalInput);
-                   m_FujixTas.ApplyRageInput(&LocalInput);
                    m_FujixTas.RecordInput(&LocalInput, Tick);
                    m_FujixTas.MaybeFinishRecord();
 


### PR DESCRIPTION
## Summary
- remove freeze rage config option
- eliminate rage mode logic from Fujix TAS component
- drop freeze rage UI checkbox and disable related input call

## Testing
- `python3 scripts/check_config_variables.py` *(fails: unused config variables)*
- `cmake -Bbuild -GNinja` *(fails: missing Opus, Opusfile, SDL2, Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_687e53d90a5c832ca69f8565cfea9dfe