### PR TITLE
Remove freeze rage feature

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -662,7 +662,6 @@ MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200,
 MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
 MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 MACRO_CONFIG_INT(ClFujixBlockFreezeLegit, cl_fujix_block_freeze_legit, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prevent collisions with freeze tiles")
-MACRO_CONFIG_INT(ClFujixBlockFreezeRage, cl_fujix_block_freeze_rage, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Autopilot movement to clicked location")
 MACRO_CONFIG_INT(ClFujixDeepfly, cl_fujix_deepfly, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable automatic hammerfly for dummy")
 MACRO_CONFIG_INT(ClFujixDeepflyHoldTicks, cl_fujix_deepfly_hold_ticks, 2, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to hold hook when deepfly")
 MACRO_CONFIG_INT(ClFujixDeepflyReleaseTicks, cl_fujix_deepfly_release_ticks, 1, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to release hook when deepfly")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -41,12 +41,8 @@ CFujixTas::CFujixTas()
     m_HookFile = nullptr;
     m_HookPlayIndex = 0;
 
-    m_RageActive = false;
     m_LastHookState = HOOK_RETRACTED;
     m_LastHookedPlayer = -1;
-    m_RageActive = false;
-    m_RageTarget = vec2(0.f, 0.f);
-    m_RagePrevEnabled = false;
 }
 
 int CFujixTas::Sizeof() const
@@ -141,68 +137,6 @@ void CFujixTas::ApplyHookEvents(int PredTick, bool ToPhantom)
     }
 }
 
-void CFujixTas::ApplyRageInput(CNetObj_PlayerInput *pInput)
-{
-    if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter || !m_RageActive)
-        return;
-
-    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
-    vec2 Diff = m_RageTarget - Pos;
-
-    if(length(Diff) < 2.0f)
-    {
-        pInput->m_Direction = 0;
-        pInput->m_Hook = 0;
-        pInput->m_Jump = 0;
-        m_RageActive = false;
-        return;
-    }
-
-    if(Diff.x > 2.0f)
-        pInput->m_Direction = 1;
-    else if(Diff.x < -2.0f)
-        pInput->m_Direction = -1;
-    else
-        pInput->m_Direction = 0;
-
-    if(Diff.y < -32.0f)
-        pInput->m_Jump = 1;
-
-    if(length(Diff) > 96.0f)
-    {
-        pInput->m_Hook = 1;
-        pInput->m_TargetX = (int)(Diff.x * 256.0f);
-        pInput->m_TargetY = (int)(Diff.y * 256.0f);
-    }
-    else
-    {
-        pInput->m_Hook = 0;
-    }
-}
-
-void CFujixTas::UpdateRageTarget()
-{
-    if(g_Config.m_ClFujixBlockFreezeRage != m_RagePrevEnabled)
-    {
-        m_RagePrevEnabled = g_Config.m_ClFujixBlockFreezeRage;
-        if(!m_RagePrevEnabled)
-            m_RageActive = false;
-        else
-        {
-            m_RageTarget = vec2(Ui()->MouseWorldX(), Ui()->MouseWorldY());
-            m_RageActive = true;
-        }
-    }
-
-    if(!g_Config.m_ClFujixBlockFreezeRage)
-        return;
-
-    if(Input()->KeyPress(KEY_MOUSE_1))
-    {
-        m_RageTarget = vec2(Ui()->MouseWorldX(), Ui()->MouseWorldY());
-        m_RageActive = true;
-    }
-}
 
 bool CFujixTas::FetchPlaybackInput(CNetObj_PlayerInput *pInput)
 {
@@ -272,7 +206,6 @@ void CFujixTas::StartRecord()
     m_LastHookState = GameClient()->m_PredictedChar.m_HookState;
     m_LastHookedPlayer = GameClient()->m_PredictedChar.HookedPlayer();
 
-    m_RageActive = false;
 
     // initialize phantom to visualize recording
     if(GameClient()->m_Snap.m_LocalClientId >= 0)
@@ -487,7 +420,6 @@ void CFujixTas::StopPlay()
     m_vHookEvents.clear();
     m_HookPlayIndex = 0;
     mem_zero(&m_CurrentInput, sizeof(m_CurrentInput));
-    m_RageActive = false;
 }
 
 void CFujixTas::StartTest()
@@ -551,7 +483,6 @@ void CFujixTas::StopTest()
     m_vEntries.clear();
     m_vHookEvents.clear();
     m_HookPlayIndex = 0;
-    m_RageActive = false;
 }
 
 void CFujixTas::TickPhantomUpTo(int TargetTick)
@@ -629,7 +560,6 @@ void CFujixTas::OnUpdate()
         StopTest();
 
     MaybeFinishRecord();
-    UpdateRageTarget();
     RecordHookState(Client()->PredGameTick(g_Config.m_ClDummy));
     TickPhantom();
 }
@@ -730,6 +660,5 @@ void CFujixTas::OnMapLoad()
     if(m_Recording)
         FinishRecord();
     StopTest();
-    m_RageActive = false;
 
 }

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -55,10 +55,6 @@ int m_HookPlayIndex;
 int m_LastHookState;
 int m_LastHookedPlayer;
 
-// Rage mode
-bool m_RageActive;
-vec2 m_RageTarget;
-bool m_RagePrevEnabled;
 
 // Phantom
 bool m_PhantomActive;
@@ -81,8 +77,6 @@ void TickPhantomUpTo(int TargetTick);
 void RecordHookState(int Tick);
 void ApplyHookEvents(int PredTick, bool ToPhantom);
 public:
-void ApplyRageInput(CNetObj_PlayerInput *pInput);
-void UpdateRageTarget();
 
 static void ConRecord(IConsole::IResult *pResult, void *pUserData);
 static void ConPlay(IConsole::IResult *pResult, void *pUserData);
@@ -112,7 +106,6 @@ void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
 void MaybeFinishRecord();
 void BlockFreezeInput(CNetObj_PlayerInput *pInput);
 void UpdateFreezeInput(CNetObj_PlayerInput *pInput); // legacy compatibility
-void SetRageTarget(vec2 Pos) { m_RageTarget = Pos; }
 };
 
 #endif // GAME_CLIENT_COMPONENTS_FUJIX_TAS_H

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3557,11 +3557,6 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
                    g_Config.m_ClFujixBlockFreezeLegit ^= 1;
 
            MainView.HSplitTop(5.0f, nullptr, &MainView);
-           CUIRect RageBox;
-           MainView.HSplitTop(ms_ButtonHeight, &RageBox, &MainView);
-           static int s_RageChk = 0;
-           if(DoButton_CheckBox(&s_RageChk, Localize("Block freeze (rage)"), g_Config.m_ClFujixBlockFreezeRage, &RageBox))
-                   g_Config.m_ClFujixBlockFreezeRage ^= 1;
     }
        else if(m_FujixPage == 2)
        {

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -548,7 +548,6 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
                if(Size > 0)
                {
                    m_FujixTas.BlockFreezeInput(&LocalInput);
-                   m_FujixTas.ApplyRageInput(&LocalInput);
                    m_FujixTas.RecordInput(&LocalInput, Tick);
                    m_FujixTas.MaybeFinishRecord();
 


### PR DESCRIPTION
## Summary
- delete `ClFujixBlockFreezeRage` setting
- remove freeze rage options in menus
- drop rage-mode logic from Fujix TAS component
- stop using rage input in `CGameClient`

## Testing
- `cargo build`
- `cargo test` *(fails: environment variable DDNET_TEST_LIBRARIES not found)*
- `cmake .. -GNinja` *(fails: You must install Opus to compile the DDNet client)*

------
https://chatgpt.com/codex/tasks/task_e_687e53d90a5c832ca69f8565cfea9dfe