### PR TITLE
Implement freeze block rage

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -662,6 +662,7 @@ MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200,
 MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
 MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 MACRO_CONFIG_INT(ClFujixBlockFreezeLegit, cl_fujix_block_freeze_legit, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prevent collisions with freeze tiles")
+MACRO_CONFIG_INT(ClFujixBlockFreezeRage, cl_fujix_block_freeze_rage, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatic freeze avoidance (rage mode)")
 MACRO_CONFIG_INT(ClFujixDeepfly, cl_fujix_deepfly, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable automatic hammerfly for dummy")
 MACRO_CONFIG_INT(ClFujixDeepflyHoldTicks, cl_fujix_deepfly_hold_ticks, 2, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to hold hook when deepfly")
 MACRO_CONFIG_INT(ClFujixDeepflyReleaseTicks, cl_fujix_deepfly_release_ticks, 1, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to release hook when deepfly")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -360,9 +360,104 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
     *pInput = Adjusted;
 }
 
+void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
+{
+    if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter)
+        return;
+
+    auto PredictFreeze = [&](const CNetObj_PlayerInput &Input, int HookMode) {
+        CCharacterCore Core = GameClient()->m_PredictedChar;
+        Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        const int Steps = 24;
+        for(int i = 0; i < Steps; i++)
+        {
+            CNetObj_PlayerInput Step = Input;
+            if(HookMode == 0)
+                Step.m_Hook = 0;
+            else if(HookMode == 1)
+                Step.m_Hook = 1;
+            else if(HookMode == 2)
+                Step.m_Hook = i == 0 ? 1 : 0;
+            Core.m_Input = Step;
+            Core.Tick(true);
+            Core.Move();
+            Core.Quantize();
+            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
+            int Tile = Collision()->GetTileIndex(Index);
+            int Front = Collision()->GetFrontTileIndex(Index);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return i + 1;
+        }
+        return 0;
+    };
+
+    int FreezeCurrent = PredictFreeze(*pInput, -1);
+    if(!FreezeCurrent)
+        return;
+
+    CNetObj_PlayerInput Adjusted = *pInput;
+
+    int FreezeNoHook = PredictFreeze(Adjusted, 0);
+    int FreezeFullHook = PredictFreeze(Adjusted, 1);
+    int FreezeShortHook = PredictFreeze(Adjusted, 2);
+
+    if(GameClient()->m_PredictedChar.m_Vel.y < 0 && FreezeFullHook &&
+       (!FreezeNoHook || FreezeFullHook <= FreezeNoHook))
+    {
+        if(!FreezeShortHook || FreezeShortHook >= FreezeFullHook)
+            Adjusted.m_Hook = 0;
+    }
+
+    if(FreezeFullHook && (!FreezeNoHook || FreezeFullHook < FreezeNoHook))
+    {
+        if(!(FreezeShortHook && (!FreezeNoHook || FreezeShortHook < FreezeNoHook)))
+            Adjusted.m_Hook = 0;
+    }
+    else if(FreezeNoHook && !FreezeFullHook)
+    {
+        Adjusted.m_Hook = 1;
+        if(GameClient()->m_PredictedChar.m_Vel.y < 0)
+            Adjusted.m_Jump = 1;
+    }
+
+    if(GameClient()->m_PredictedChar.m_Vel.y > 1.0f)
+        Adjusted.m_Jump = 1;
+
+    CCharacter *pLocalChar = GameClient()->m_PredictedWorld.GetCharacterById(GameClient()->m_Snap.m_LocalClientId);
+    bool OnGround = pLocalChar && pLocalChar->IsGrounded();
+
+    if(!OnGround)
+    {
+        float VelX = GameClient()->m_PredictedChar.m_Vel.x;
+        if(VelX > 0.5f)
+            Adjusted.m_Direction = -1;
+        else if(VelX < -0.5f)
+            Adjusted.m_Direction = 1;
+        else
+            Adjusted.m_Direction = 0;
+
+        if(FreezeCurrent <= 5)
+        {
+            if(VelX > 0.1f)
+                Adjusted.m_Direction = -1;
+            else if(VelX < -0.1f)
+                Adjusted.m_Direction = 1;
+        }
+    }
+    else
+        Adjusted.m_Direction = 0;
+
+    *pInput = Adjusted;
+}
+
 void CFujixTas::UpdateFreezeInput(CNetObj_PlayerInput *pInput)
 {
-    BlockFreezeInput(pInput);
+    if(g_Config.m_ClFujixBlockFreezeRage)
+        BlockFreezeRageInput(pInput);
+    else
+        BlockFreezeInput(pInput);
 }
 
 void CFujixTas::StartPlay()

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -105,6 +105,7 @@ bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
 void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
 void MaybeFinishRecord();
 void BlockFreezeInput(CNetObj_PlayerInput *pInput);
+void BlockFreezeRageInput(CNetObj_PlayerInput *pInput);
 void UpdateFreezeInput(CNetObj_PlayerInput *pInput); // legacy compatibility
 };
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3557,6 +3557,16 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
                    g_Config.m_ClFujixBlockFreezeLegit ^= 1;
 
            MainView.HSplitTop(5.0f, nullptr, &MainView);
+
+           CUIRect RageBlockBox, RageIcon;
+           MainView.HSplitTop(ms_ButtonHeight, &RageBlockBox, &MainView);
+           RageBlockBox.VSplitLeft(RageBlockBox.h, &RageIcon, &RageBlockBox);
+           Ui()->DoLabel(&RageIcon, FONT_ICON_LOCK, RageBlockBox.h * 0.7f, TEXTALIGN_MC);
+           static int s_BlockRageChk = 0;
+           if(DoButton_CheckBox(&s_BlockRageChk, Localize("Block freeze (rage)"), g_Config.m_ClFujixBlockFreezeRage, &RageBlockBox))
+                   g_Config.m_ClFujixBlockFreezeRage ^= 1;
+
+           MainView.HSplitTop(5.0f, nullptr, &MainView);
     }
        else if(m_FujixPage == 2)
        {

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -547,7 +547,7 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 
                if(Size > 0)
                {
-                   m_FujixTas.BlockFreezeInput(&LocalInput);
+                   m_FujixTas.UpdateFreezeInput(&LocalInput);
                    m_FujixTas.RecordInput(&LocalInput, Tick);
                    m_FujixTas.MaybeFinishRecord();
 


### PR DESCRIPTION
## Summary
- add new config variable `cl_fujix_block_freeze_rage`
- add UI toggle for rage mode
- implement `BlockFreezeRageInput` for aggressive freeze avoidance
- allow selecting rage/legit mode in freeze helper

## Testing
- `python3 scripts/check_config_variables.py` *(fails: unused config variables)*
- `python3 scripts/check_header_guards.py`
- `bash scripts/check_standard_headers.sh`
- `python3 scripts/check_unused_header_files.py`


------
https://chatgpt.com/codex/tasks/task_e_687e65947c8c832ca9e667b256b94acd