### PR TITLE
Improve freeze block rage

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -662,6 +662,7 @@ MACRO_CONFIG_INT(ClFujixTasPreviewTicks, cl_fujix_tas_preview_ticks, 40, 0, 200,
 MACRO_CONFIG_INT(ClFujixTasShowPlayers, cl_fujix_tas_show_players, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players while recording TAS")
 MACRO_CONFIG_INT(ClFujixTasRouteTicks, cl_fujix_tas_route_ticks, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks ahead for recommended route (0 to disable)")
 MACRO_CONFIG_INT(ClFujixBlockFreezeLegit, cl_fujix_block_freeze_legit, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prevent collisions with freeze tiles")
+MACRO_CONFIG_INT(ClFujixBlockFreezeRage, cl_fujix_block_freeze_rage, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatic freeze avoidance (rage mode)")
 MACRO_CONFIG_INT(ClFujixDeepfly, cl_fujix_deepfly, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable automatic hammerfly for dummy")
 MACRO_CONFIG_INT(ClFujixDeepflyHoldTicks, cl_fujix_deepfly_hold_ticks, 2, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to hold hook when deepfly")
 MACRO_CONFIG_INT(ClFujixDeepflyReleaseTicks, cl_fujix_deepfly_release_ticks, 1, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ticks to release hook when deepfly")

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -365,6 +365,17 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter)
         return;
 
+    const CCharacterCore &Pred = GameClient()->m_PredictedChar;
+
+    if(Pred.m_HookState != HOOK_IDLE)
+    {
+        pInput->m_Hook = 1;
+        return;
+    }
+
+    if(pInput->m_Hook)
+        return;
+
     const int Steps = 24;
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
@@ -395,10 +406,10 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     int BestFreeze = FreezeCurrent;
 
     static const vec2 s_aDirs[] = {
-        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f),
-        vec2(-1.f, 0.f), vec2(1.f, 1.f), vec2(-1.f, 1.f)};
+        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f),
+        vec2(1.f, 0.f), vec2(-1.f, 0.f)};
 
-    const float AimLen = 200.0f;
+    const float AimLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
     for(const vec2 &Dir : s_aDirs)
     {
         vec2 Pos = GameClient()->m_PredictedChar.m_Pos;

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -365,10 +365,10 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter)
         return;
 
+    const int Steps = 24;
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
-        const int Steps = 24;
         for(int i = 0; i < Steps; i++)
         {
             Core.m_Input = Input;
@@ -402,7 +402,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     for(const vec2 &Dir : s_aDirs)
     {
         vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
-        vec2 To = Pos + Dir * GetTuning(g_Config.m_ClDummy)->m_HookLength;
+        vec2 To = Pos + Dir * GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
         vec2 Col;
         int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
         if(Hit && Hit != TILE_NOHOOK)

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -360,9 +360,78 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
     *pInput = Adjusted;
 }
 
+void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
+{
+    if(!g_Config.m_ClFujixBlockFreezeRage || !GameClient()->m_Snap.m_pLocalCharacter)
+        return;
+
+    auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
+        CCharacterCore Core = GameClient()->m_PredictedChar;
+        Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        const int Steps = 24;
+        for(int i = 0; i < Steps; i++)
+        {
+            Core.m_Input = Input;
+            Core.Tick(true);
+            Core.Move();
+            Core.Quantize();
+            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
+            int Tile = Collision()->GetTileIndex(Index);
+            int Front = Collision()->GetFrontTileIndex(Index);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return i + 1;
+        }
+        return 0;
+    };
+
+    CNetObj_PlayerInput Base = *pInput;
+    int FreezeCurrent = PredictFreeze(Base);
+    if(!FreezeCurrent)
+        return;
+
+    CNetObj_PlayerInput Best = Base;
+    int BestFreeze = FreezeCurrent;
+
+    static const vec2 s_aDirs[] = {
+        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f),
+        vec2(-1.f, 0.f), vec2(1.f, 1.f), vec2(-1.f, 1.f)};
+
+    const float AimLen = 200.0f;
+    for(const vec2 &Dir : s_aDirs)
+    {
+        vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+        vec2 To = Pos + Dir * GetTuning(g_Config.m_ClDummy)->m_HookLength;
+        vec2 Col;
+        int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
+        if(Hit && Hit != TILE_NOHOOK)
+        {
+            CNetObj_PlayerInput Test = Base;
+            Test.m_Hook = 1;
+            Test.m_TargetX = (int)(Dir.x * AimLen);
+            Test.m_TargetY = (int)(Dir.y * AimLen);
+            int Freeze = PredictFreeze(Test);
+            if(!Freeze || (BestFreeze && Freeze > BestFreeze))
+            {
+                Best = Test;
+                BestFreeze = Freeze ? Freeze : Steps;
+                if(!Freeze)
+                    break;
+            }
+        }
+    }
+
+    if(BestFreeze > FreezeCurrent)
+        *pInput = Best;
+}
+
 void CFujixTas::UpdateFreezeInput(CNetObj_PlayerInput *pInput)
 {
-    BlockFreezeInput(pInput);
+    if(g_Config.m_ClFujixBlockFreezeRage)
+        BlockFreezeRageInput(pInput);
+    else
+        BlockFreezeInput(pInput);
 }
 
 void CFujixTas::StartPlay()

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -105,6 +105,7 @@ bool FetchPlaybackInput(CNetObj_PlayerInput *pInput);
 void RecordInput(const CNetObj_PlayerInput *pInput, int Tick);
 void MaybeFinishRecord();
 void BlockFreezeInput(CNetObj_PlayerInput *pInput);
+void BlockFreezeRageInput(CNetObj_PlayerInput *pInput);
 void UpdateFreezeInput(CNetObj_PlayerInput *pInput); // legacy compatibility
 };
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3557,6 +3557,16 @@ void CMenus::RenderSettingsFujix(CUIRect MainView)
                    g_Config.m_ClFujixBlockFreezeLegit ^= 1;
 
            MainView.HSplitTop(5.0f, nullptr, &MainView);
+
+           CUIRect RageBlockBox, RageIcon;
+           MainView.HSplitTop(ms_ButtonHeight, &RageBlockBox, &MainView);
+           RageBlockBox.VSplitLeft(RageBlockBox.h, &RageIcon, &RageBlockBox);
+           Ui()->DoLabel(&RageIcon, FONT_ICON_LOCK, RageBlockBox.h * 0.7f, TEXTALIGN_MC);
+           static int s_BlockRageChk = 0;
+           if(DoButton_CheckBox(&s_BlockRageChk, Localize("Block freeze (rage)"), g_Config.m_ClFujixBlockFreezeRage, &RageBlockBox))
+                   g_Config.m_ClFujixBlockFreezeRage ^= 1;
+
+           MainView.HSplitTop(5.0f, nullptr, &MainView);
     }
        else if(m_FujixPage == 2)
        {

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -547,7 +547,7 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 
                if(Size > 0)
                {
-                   m_FujixTas.BlockFreezeInput(&LocalInput);
+                   m_FujixTas.UpdateFreezeInput(&LocalInput);
                    m_FujixTas.RecordInput(&LocalInput, Tick);
                    m_FujixTas.MaybeFinishRecord();
 


### PR DESCRIPTION
## Summary
- upgrade freeze block rage logic to automatically aim the hook
- keep checkbox for enabling rage mode

## Testing
- `python3 scripts/check_config_variables.py` *(fails: unused config variables)*
- `python3 scripts/check_header_guards.py`
- `bash scripts/check_standard_headers.sh`
- `python3 scripts/check_unused_header_files.py`


------
https://chatgpt.com/codex/tasks/task_e_687e65947c8c832ca9e667b256b94acd