### PR TITLE
Stop freeze rage hook after attachment

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -370,6 +370,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     {
         pInput->m_Hook = 1;
         m_RageHookTicks--;
+        if(GameClient()->m_PredictedChar.m_HookState != HOOK_FLYING)
+            m_RageHookTicks = 0;
         return;
     }
 
@@ -401,6 +403,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
 
     CNetObj_PlayerInput Best = Base;
     int BestFreeze = FreezeCurrent;
+    vec2 BestCol = vec2(0.f, 0.f);
+    bool BestWall = false;
 
     if(pInput->m_Hook)
         return;
@@ -411,8 +415,13 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
     const float AimLen = HookLen;
-    for(const vec2 &Dir : s_aDirs)
+    for(const vec2 &DirRaw : s_aDirs)
     {
+        vec2 Dir = DirRaw;
+        bool Wall = Dir.y == 0.f && Dir.x != 0.f;
+        if(Wall)
+            Dir.y = -0.25f; // aim slightly upward when hooking a wall
+        Dir = normalize(Dir);
         vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
         vec2 To = Pos + Dir * HookLen;
         vec2 Col;
@@ -428,6 +437,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             {
                 Best = Test;
                 BestFreeze = Freeze ? Freeze : Steps;
+                BestCol = Col;
+                BestWall = Wall;
                 if(!Freeze)
                     break;
             }
@@ -437,7 +448,17 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(BestFreeze > FreezeCurrent)
     {
         *pInput = Best;
-        m_RageHookTicks = RAGE_HOOK_HOLD;
+        if(BestWall)
+        {
+            vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+            pInput->m_Direction = Pos.x < BestCol.x ? -1 : 1; // move away from the wall
+        }
+        float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
+        float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
+        int Hold = (int)ceilf(Dist / Speed) + 1;
+        if(Hold < RAGE_HOOK_HOLD_MIN)
+            Hold = RAGE_HOOK_HOLD_MIN;
+        m_RageHookTicks = Hold;
     }
 }
 

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -66,7 +66,7 @@ int m_PhantomStep;
 CNetObj_PlayerInput m_PhantomInput;
 int m_PhantomPlayIndex;
 int m_RageHookTicks;
-static const int RAGE_HOOK_HOLD = 6;
+static const int RAGE_HOOK_HOLD_MIN = 6;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;


### PR DESCRIPTION
## Summary
- stop freeze rage hook once it attaches or fails to fly
- aim rage hook slightly upwards when grabbing walls
- move away from hooked walls to avoid getting stuck

## Testing
- `cmake -B build -GNinja` *(fails: missing Rust, SDL2, Vulkan, etc.)*
- `cmake --build build --target run_tests` *(not executed due to previous failure)*


------
https://chatgpt.com/codex/tasks/task_e_687f602620cc832c94eff9ea2d621298