### PR TITLE
Improve freeze rage prediction

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -432,6 +432,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             Test.m_Hook = 1;
             Test.m_TargetX = (int)(Dir.x * AimLen);
             Test.m_TargetY = (int)(Dir.y * AimLen);
+            if(Wall)
+                Test.m_Direction = Pos.x < Col.x ? -1 : 1; // predict moving away from the wall
             int Freeze = PredictFreeze(Test);
             if(!Freeze || Freeze > BestFreeze)
             {


### PR DESCRIPTION
## Summary
- make predictions account for moving away from hooked walls

## Testing
- `python3 scripts/fix_style.py --dry-run` *(fails: `Found no clang-format 10`)*

------
https://chatgpt.com/codex/tasks/task_e_687f7fdb8a14832c85823d4f3c645d37