### PR TITLE
Implement wall avoidance in freeze rage

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -45,6 +45,7 @@ CFujixTas::CFujixTas()
     m_LastHookedPlayer = -1;
     m_RageHookTicks = 0;
     m_RageMoveDir = 0;
+    m_RageMoveTicks = 0;
 }
 
 int CFujixTas::Sizeof() const
@@ -373,11 +374,18 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         pInput->m_Direction = m_RageMoveDir;
         m_RageHookTicks--;
         if(GameClient()->m_PredictedChar.m_HookState != HOOK_FLYING)
-        {
             m_RageHookTicks = 0;
+        if(m_RageHookTicks == 0 && m_RageMoveTicks == 0)
             m_RageMoveDir = 0;
-        }
         return;
+    }
+
+    if(m_RageMoveTicks > 0)
+    {
+        pInput->m_Direction = m_RageMoveDir;
+        m_RageMoveTicks--;
+        if(m_RageMoveTicks == 0)
+            m_RageMoveDir = 0;
     }
 
     const int Steps = 24;
@@ -406,6 +414,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(!FreezeCurrent)
     {
         m_RageMoveDir = 0;
+        m_RageMoveTicks = 0;
         return;
     }
 
@@ -417,6 +426,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(pInput->m_Hook)
     {
         m_RageMoveDir = 0;
+        m_RageMoveTicks = 0;
         return;
     }
 
@@ -426,6 +436,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
     const float AimLen = HookLen;
+    int BestDir = 0;
     for(const vec2 &DirRaw : s_aDirs)
     {
         vec2 Dir = DirRaw;
@@ -439,51 +450,36 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
         if(Hit && Hit != TILE_NOHOOK)
         {
-            CNetObj_PlayerInput Test = Base;
-            Test.m_Hook = 1;
-            Test.m_TargetX = (int)(Dir.x * AimLen);
-            Test.m_TargetY = (int)(Dir.y * AimLen);
-            int Freeze = PredictFreeze(Test);
-            if(!Freeze || Freeze > BestFreeze)
+            static const int aMove[] = {-1, 0, 1};
+            for(int Move : aMove)
             {
-                Best = Test;
-                BestFreeze = Freeze ? Freeze : Steps;
-                BestCol = Col;
-                BestWall = Wall;
-                if(!Freeze)
-                    break;
+                CNetObj_PlayerInput Test = Base;
+                Test.m_Hook = 1;
+                Test.m_TargetX = (int)(Dir.x * AimLen);
+                Test.m_TargetY = (int)(Dir.y * AimLen);
+                Test.m_Direction = Move;
+                int Freeze = PredictFreeze(Test);
+                if(!Freeze || Freeze > BestFreeze)
+                {
+                    Best = Test;
+                    BestFreeze = Freeze ? Freeze : Steps;
+                    BestCol = Col;
+                    BestWall = Wall;
+                    BestDir = Move;
+                    if(!Freeze)
+                        break;
+                }
             }
+            if(BestFreeze == Steps)
+                break;
         }
     }
 
     if(BestFreeze > FreezeCurrent)
     {
         *pInput = Best;
-
-        // Evaluate horizontal compensation while the hook is held.
-        static const int aDirs[] = {-1, 0, 1};
-        int MoveDir = 0;
-        int BestDirFreeze = -1;
-        for(int Dir : aDirs)
-        {
-            CNetObj_PlayerInput Test = Best;
-            Test.m_Direction = Dir;
-            int Freeze = PredictFreeze(Test);
-            if(Freeze == 0)
-            {
-                MoveDir = Dir;
-                BestDirFreeze = Steps;
-                break;
-            }
-            if(Freeze > BestDirFreeze)
-            {
-                BestDirFreeze = Freeze;
-                MoveDir = Dir;
-            }
-        }
-
-        m_RageMoveDir = MoveDir;
-        pInput->m_Direction = MoveDir;
+        m_RageMoveDir = BestDir;
+        pInput->m_Direction = BestDir;
 
         float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
         float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
@@ -491,6 +487,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         if(Hold < RAGE_HOOK_HOLD_MIN)
             Hold = RAGE_HOOK_HOLD_MIN;
         m_RageHookTicks = Hold;
+        m_RageMoveTicks = Hold + RAGE_MOVE_EXTRA;
     }
 }
 

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -463,11 +463,13 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         }
     }
 
-    std::vector<vec2> vDirs = {
-        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(0.5f, -1.f),
-        vec2(-0.5f, -1.f), vec2(0.75f, -1.f), vec2(-0.75f, -1.f),
-        vec2(1.f, 0.f),  vec2(-1.f, 0.f),
-        vec2(0.f, 1.f),  vec2(1.f, 1.f),  vec2(-1.f, 1.f)};
+    std::vector<vec2> vDirs;
+    vDirs.reserve(RAGE_DIR_TOTAL + 6);
+    for(int i = 0; i < RAGE_DIR_TOTAL; i++)
+    {
+        float a = 2.f * pi * i / RAGE_DIR_TOTAL;
+        vDirs.push_back(vec2(cosf(a), sinf(a)));
+    }
     int WantedDir = clamp(Base.m_Direction, -1, 1);
     if(WantedDir)
     {

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -44,6 +44,7 @@ CFujixTas::CFujixTas()
     m_LastHookState = HOOK_RETRACTED;
     m_LastHookedPlayer = -1;
     m_RageHookTicks = 0;
+    m_RageMoveDir = 0;
 }
 
 int CFujixTas::Sizeof() const
@@ -369,9 +370,13 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(m_RageHookTicks > 0)
     {
         pInput->m_Hook = 1;
+        pInput->m_Direction = m_RageMoveDir;
         m_RageHookTicks--;
         if(GameClient()->m_PredictedChar.m_HookState != HOOK_FLYING)
+        {
             m_RageHookTicks = 0;
+            m_RageMoveDir = 0;
+        }
         return;
     }
 
@@ -399,7 +404,10 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     CNetObj_PlayerInput Base = *pInput;
     int FreezeCurrent = PredictFreeze(Base);
     if(!FreezeCurrent)
+    {
+        m_RageMoveDir = 0;
         return;
+    }
 
     CNetObj_PlayerInput Best = Base;
     int BestFreeze = FreezeCurrent;
@@ -407,7 +415,10 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     bool BestWall = false;
 
     if(pInput->m_Hook)
+    {
+        m_RageMoveDir = 0;
         return;
+    }
 
     static const vec2 s_aDirs[] = {
         vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f),
@@ -451,8 +462,11 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         if(BestWall)
         {
             vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
-            pInput->m_Direction = Pos.x < BestCol.x ? -1 : 1; // move away from the wall
+            m_RageMoveDir = Pos.x < BestCol.x ? -1 : 1; // move away from the wall
+            pInput->m_Direction = m_RageMoveDir;
         }
+        else
+            m_RageMoveDir = 0;
         float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
         float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
         int Hold = (int)ceilf(Dist / Speed) + 1;

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -389,7 +389,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             m_RageMoveDir = 0;
     }
 
-    const int Steps = 24;
+    const int Steps = RAGE_PREDICT_STEPS;
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
@@ -431,12 +431,16 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         return;
     }
 
-    std::vector<vec2> vDirs = {vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f), vec2(-1.f, 0.f)};
+    std::vector<vec2> vDirs = {
+        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(0.5f, -1.f),
+        vec2(-0.5f, -1.f), vec2(0.75f, -1.f), vec2(-0.75f, -1.f),
+        vec2(1.f, 0.f), vec2(-1.f, 0.f)};
     int WantedDir = clamp(Base.m_Direction, -1, 1);
     if(WantedDir)
     {
         vDirs.push_back(normalize(vec2(WantedDir * 0.25f, -1.f)));
         vDirs.push_back(normalize(vec2(WantedDir * 0.5f, -1.f)));
+        vDirs.push_back(normalize(vec2(WantedDir * 0.75f, -1.f)));
     }
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
@@ -476,6 +480,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
                 Test.m_TargetY = (int)(Dir.y * AimLen);
                 Test.m_Direction = Move;
                 int Freeze = PredictFreeze(Test);
+                if(Freeze && Freeze <= RAGE_HOOK_HOLD_MIN)
+                    continue;
                 if(!Freeze || Freeze > BestFreeze)
                 {
                     Best = Test;
@@ -501,6 +507,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
         float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
         int Hold = (int)ceilf(Dist / Speed) + 1;
+        if(BestFreeze && BestFreeze < Hold)
+            Hold = BestFreeze - 1;
         if(Hold < RAGE_HOOK_HOLD_MIN)
             Hold = RAGE_HOOK_HOLD_MIN;
         else if(Hold > RAGE_HOOK_HOLD_MAX)

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -483,7 +483,10 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     auto PredictFreezeSeq = [&](const vec2 &Dir, int Move, int Hold) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
-        for(int i = 0; i < Steps; i++)
+        int StepLimit = Hold + RAGE_EXTRA_AFTER_HOLD;
+        if(StepLimit < Steps)
+            StepLimit = Steps;
+        for(int i = 0; i < StepLimit; i++)
         {
             CNetObj_PlayerInput Step = Base;
             Step.m_Direction = Move;

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -12,6 +12,7 @@
 #include <game/client/components/players.h>
 #include <game/client/prediction/entities/character.h>
 #include <base/system.h>
+#include <vector>
 #include <cstdlib>
 #include <ctime>
 #include <cmath>
@@ -430,14 +431,18 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         return;
     }
 
-    static const vec2 s_aDirs[] = {
-        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f),
-        vec2(-1.f, 0.f)};
+    std::vector<vec2> vDirs = {vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f), vec2(-1.f, 0.f)};
+    int WantedDir = clamp(Base.m_Direction, -1, 1);
+    if(WantedDir)
+    {
+        vDirs.push_back(normalize(vec2(WantedDir * 0.25f, -1.f)));
+        vDirs.push_back(normalize(vec2(WantedDir * 0.5f, -1.f)));
+    }
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
     const float AimLen = HookLen;
     int BestDir = 0;
-    for(const vec2 &DirRaw : s_aDirs)
+    for(const vec2 &DirRaw : vDirs)
     {
         vec2 Dir = DirRaw;
         bool Wall = Dir.y == 0.f && Dir.x != 0.f;
@@ -450,7 +455,19 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
         if(Hit && Hit != TILE_NOHOOK)
         {
-            static const int aMove[] = {-1, 0, 1};
+            int aMove[3];
+            if(WantedDir)
+            {
+                aMove[0] = WantedDir;
+                aMove[1] = 0;
+                aMove[2] = -WantedDir;
+            }
+            else
+            {
+                aMove[0] = 0;
+                aMove[1] = 1;
+                aMove[2] = -1;
+            }
             for(int Move : aMove)
             {
                 CNetObj_PlayerInput Test = Base;
@@ -486,6 +503,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         int Hold = (int)ceilf(Dist / Speed) + 1;
         if(Hold < RAGE_HOOK_HOLD_MIN)
             Hold = RAGE_HOOK_HOLD_MIN;
+        else if(Hold > RAGE_HOOK_HOLD_MAX)
+            Hold = RAGE_HOOK_HOLD_MAX;
         m_RageHookTicks = Hold;
         m_RageMoveTicks = Hold + RAGE_MOVE_EXTRA;
     }

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -459,14 +459,32 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(BestFreeze > FreezeCurrent)
     {
         *pInput = Best;
-        if(BestWall)
+
+        // Evaluate horizontal compensation while the hook is held.
+        static const int aDirs[] = {-1, 0, 1};
+        int MoveDir = 0;
+        int BestDirFreeze = -1;
+        for(int Dir : aDirs)
         {
-            vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
-            m_RageMoveDir = Pos.x < BestCol.x ? -1 : 1; // move away from the wall
-            pInput->m_Direction = m_RageMoveDir;
+            CNetObj_PlayerInput Test = Best;
+            Test.m_Direction = Dir;
+            int Freeze = PredictFreeze(Test);
+            if(Freeze == 0)
+            {
+                MoveDir = Dir;
+                BestDirFreeze = Steps;
+                break;
+            }
+            if(Freeze > BestDirFreeze)
+            {
+                BestDirFreeze = Freeze;
+                MoveDir = Dir;
+            }
         }
-        else
-            m_RageMoveDir = 0;
+
+        m_RageMoveDir = MoveDir;
+        pInput->m_Direction = MoveDir;
+
         float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
         float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
         int Hold = (int)ceilf(Dist / Speed) + 1;

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -422,7 +422,6 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     CNetObj_PlayerInput Best = Base;
     int BestFreeze = FreezeCurrent;
     vec2 BestCol = vec2(0.f, 0.f);
-    bool BestWall = false;
 
     if(pInput->m_Hook)
     {
@@ -445,7 +444,37 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
     const float AimLen = HookLen;
+    float HookSpeed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
+
+    auto PredictFreezeSeq = [&](const vec2 &Dir, int Move, int Hold) {
+        CCharacterCore Core = GameClient()->m_PredictedChar;
+        Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        for(int i = 0; i < Steps; i++)
+        {
+            CNetObj_PlayerInput Step = Base;
+            Step.m_Direction = Move;
+            if(i == 0)
+            {
+                Step.m_TargetX = (int)(Dir.x * AimLen);
+                Step.m_TargetY = (int)(Dir.y * AimLen);
+            }
+            Step.m_Hook = i < Hold ? 1 : 0;
+            Core.m_Input = Step;
+            Core.Tick(true);
+            Core.Move();
+            Core.Quantize();
+            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
+            int Tile = Collision()->GetTileIndex(Index);
+            int Front = Collision()->GetFrontTileIndex(Index);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return i + 1;
+        }
+        return 0;
+    };
     int BestDir = 0;
+    int BestHold = 0;
     for(const vec2 &DirRaw : vDirs)
     {
         vec2 Dir = DirRaw;
@@ -474,21 +503,31 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             }
             for(int Move : aMove)
             {
-                CNetObj_PlayerInput Test = Base;
-                Test.m_Hook = 1;
-                Test.m_TargetX = (int)(Dir.x * AimLen);
-                Test.m_TargetY = (int)(Dir.y * AimLen);
-                Test.m_Direction = Move;
-                int Freeze = PredictFreeze(Test);
-                if(Freeze && Freeze <= RAGE_HOOK_HOLD_MIN)
+                float Dist = distance(Pos, Col);
+                int Hold = (int)ceilf(Dist / HookSpeed) + 1;
+                if(Hold < RAGE_HOOK_HOLD_MIN)
+                    Hold = RAGE_HOOK_HOLD_MIN;
+                else if(Hold > RAGE_HOOK_HOLD_MAX)
+                    Hold = RAGE_HOOK_HOLD_MAX;
+                int Freeze = PredictFreezeSeq(Dir, Move, Hold);
+                if(Freeze && Freeze <= Hold && Hold > 1)
+                {
+                    Hold = Freeze - 1;
+                    Freeze = PredictFreezeSeq(Dir, Move, Hold);
+                }
+                if(Freeze && Freeze <= Hold)
                     continue;
                 if(!Freeze || Freeze > BestFreeze)
                 {
-                    Best = Test;
+                    Best = Base;
+                    Best.m_Hook = 1;
+                    Best.m_TargetX = (int)(Dir.x * AimLen);
+                    Best.m_TargetY = (int)(Dir.y * AimLen);
+                    Best.m_Direction = Move;
                     BestFreeze = Freeze ? Freeze : Steps;
                     BestCol = Col;
-                    BestWall = Wall;
                     BestDir = Move;
+                    BestHold = Hold;
                     if(!Freeze)
                         break;
                 }
@@ -504,17 +543,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         m_RageMoveDir = BestDir;
         pInput->m_Direction = BestDir;
 
-        float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
-        float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
-        int Hold = (int)ceilf(Dist / Speed) + 1;
-        if(BestFreeze && BestFreeze < Hold)
-            Hold = BestFreeze - 1;
-        if(Hold < RAGE_HOOK_HOLD_MIN)
-            Hold = RAGE_HOOK_HOLD_MIN;
-        else if(Hold > RAGE_HOOK_HOLD_MAX)
-            Hold = RAGE_HOOK_HOLD_MAX;
-        m_RageHookTicks = Hold;
-        m_RageMoveTicks = Hold + RAGE_MOVE_EXTRA;
+        m_RageHookTicks = BestHold;
+        m_RageMoveTicks = BestHold + RAGE_MOVE_EXTRA;
     }
 }
 

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -425,15 +425,20 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
 
     if(pInput->m_Hook)
     {
-        m_RageMoveDir = 0;
-        m_RageMoveTicks = 0;
-        return;
+        int Freeze = PredictFreeze(Base);
+        if(!Freeze)
+        {
+            m_RageMoveDir = 0;
+            m_RageMoveTicks = 0;
+            return;
+        }
     }
 
     std::vector<vec2> vDirs = {
         vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(0.5f, -1.f),
         vec2(-0.5f, -1.f), vec2(0.75f, -1.f), vec2(-0.75f, -1.f),
-        vec2(1.f, 0.f), vec2(-1.f, 0.f)};
+        vec2(1.f, 0.f),  vec2(-1.f, 0.f),
+        vec2(0.f, 1.f),  vec2(1.f, 1.f),  vec2(-1.f, 1.f)};
     int WantedDir = clamp(Base.m_Direction, -1, 1);
     if(WantedDir)
     {
@@ -486,7 +491,13 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         vec2 To = Pos + Dir * HookLen;
         vec2 Col;
         int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
-        if(Hit && Hit != TILE_NOHOOK)
+        int ColIndex = Collision()->GetPureMapIndex(Col.x, Col.y);
+        int ColTile = Collision()->GetTileIndex(ColIndex);
+        int ColFront = Collision()->GetFrontTileIndex(ColIndex);
+        bool ColFreeze = ColTile == TILE_FREEZE || ColTile == TILE_DFREEZE ||
+                         ColTile == TILE_LFREEZE || ColFront == TILE_FREEZE ||
+                         ColFront == TILE_DFREEZE || ColFront == TILE_LFREEZE;
+        if(Hit && Hit != TILE_NOHOOK && !ColFreeze)
         {
             int aMove[3];
             if(WantedDir)
@@ -504,7 +515,11 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             for(int Move : aMove)
             {
                 float Dist = distance(Pos, Col);
-                int Hold = (int)ceilf(Dist / HookSpeed) + 1;
+                int Hold;
+                if(DirRaw.y > 0.f)
+                    Hold = RAGE_HOOK_DOWN_HOLD;
+                else
+                    Hold = (int)ceilf(Dist / HookSpeed) + 1;
                 if(Hold < RAGE_HOOK_HOLD_MIN)
                     Hold = RAGE_HOOK_HOLD_MIN;
                 else if(Hold > RAGE_HOOK_HOLD_MAX)

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -12,6 +12,7 @@
 #include <game/client/components/players.h>
 #include <game/client/prediction/entities/character.h>
 #include <base/system.h>
+#include <array>
 #include <vector>
 #include <cstdlib>
 #include <ctime>
@@ -280,6 +281,25 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
     if(!g_Config.m_ClFujixBlockFreezeLegit || !GameClient()->m_Snap.m_pLocalCharacter)
         return;
 
+    auto NearFreeze = [&](vec2 Pos) {
+        const float Half = CCharacterCore::PhysicalSize() / 2.f;
+        std::array<vec2,5> aOff = {vec2(0.f, 0.f),
+                                   vec2(0.f, -Half - RAGE_NEAR_MARGIN),
+                                   vec2(0.f, Half + RAGE_NEAR_MARGIN),
+                                   vec2(Half + RAGE_NEAR_MARGIN, 0.f),
+                                   vec2(-Half - RAGE_NEAR_MARGIN, 0.f)};
+        for(const vec2 &Off : aOff)
+        {
+            int Idx = Collision()->GetPureMapIndex(Pos.x + Off.x, Pos.y + Off.y);
+            int Tile = Collision()->GetTileIndex(Idx);
+            int Front = Collision()->GetFrontTileIndex(Idx);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return true;
+        }
+        return false;
+    };
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input, int HookMode) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
@@ -297,12 +317,7 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
             Core.Tick(true);
             Core.Move();
             Core.Quantize();
-            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
-            int Tile = Collision()->GetTileIndex(Index);
-            int Front = Collision()->GetFrontTileIndex(Index);
-            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
-                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
-            if(Freeze)
+            if(NearFreeze(Core.m_Pos))
                 return i + 1;
         }
         return 0;
@@ -390,6 +405,25 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     }
 
     const int Steps = RAGE_PREDICT_STEPS;
+    auto NearFreeze = [&](vec2 Pos) {
+        const float Half = CCharacterCore::PhysicalSize() / 2.f;
+        std::array<vec2,5> aOff = {vec2(0.f, 0.f),
+                                   vec2(0.f, -Half - RAGE_NEAR_MARGIN),
+                                   vec2(0.f, Half + RAGE_NEAR_MARGIN),
+                                   vec2(Half + RAGE_NEAR_MARGIN, 0.f),
+                                   vec2(-Half - RAGE_NEAR_MARGIN, 0.f)};
+        for(const vec2 &Off : aOff)
+        {
+            int Idx = Collision()->GetPureMapIndex(Pos.x + Off.x, Pos.y + Off.y);
+            int Tile = Collision()->GetTileIndex(Idx);
+            int Front = Collision()->GetFrontTileIndex(Idx);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return true;
+        }
+        return false;
+    };
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
@@ -399,12 +433,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             Core.Tick(true);
             Core.Move();
             Core.Quantize();
-            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
-            int Tile = Collision()->GetTileIndex(Index);
-            int Front = Collision()->GetFrontTileIndex(Index);
-            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
-                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
-            if(Freeze)
+            if(NearFreeze(Core.m_Pos))
                 return i + 1;
         }
         return 0;
@@ -468,12 +497,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             Core.Tick(true);
             Core.Move();
             Core.Quantize();
-            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
-            int Tile = Collision()->GetTileIndex(Index);
-            int Front = Collision()->GetFrontTileIndex(Index);
-            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
-                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
-            if(Freeze)
+            if(NearFreeze(Core.m_Pos))
                 return i + 1;
         }
         return 0;

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -483,7 +483,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     auto PredictFreezeSeq = [&](const vec2 &Dir, int Move, int Hold) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
-        int StepLimit = Hold + RAGE_EXTRA_AFTER_HOLD;
+        int StepLimit = Hold + RAGE_EXTRA_AFTER_HOLD + RAGE_RELEASE_SAFE;
         if(StepLimit < Steps)
             StepLimit = Steps;
         for(int i = 0; i < StepLimit; i++)
@@ -558,6 +558,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
                     Freeze = PredictFreezeSeq(Dir, Move, Hold);
                 }
                 if(Freeze && Freeze <= Hold)
+                    continue;
+                if(Freeze && Freeze <= Hold + RAGE_RELEASE_SAFE)
                     continue;
                 if(!Freeze || Freeze > BestFreeze)
                 {

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -71,11 +71,12 @@ int m_RageMoveTicks;
 static constexpr int RAGE_HOOK_HOLD_MIN = 6;
 static constexpr int RAGE_HOOK_HOLD_MAX = 20;
 static constexpr int RAGE_MOVE_EXTRA = 4;
-static constexpr int RAGE_PREDICT_STEPS = 25;
+static constexpr int RAGE_PREDICT_STEPS = 30;
 static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
 static constexpr float RAGE_NEAR_MARGIN = 6.f;
 static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
 static constexpr int RAGE_RELEASE_SAFE = 6;
+static constexpr int RAGE_DIR_TOTAL = 24;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -71,6 +71,7 @@ int m_RageMoveTicks;
 static const int RAGE_HOOK_HOLD_MIN = 6;
 static const int RAGE_HOOK_HOLD_MAX = 20;
 static const int RAGE_MOVE_EXTRA = 4;
+static const int RAGE_PREDICT_STEPS = 25;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -66,6 +66,7 @@ int m_PhantomStep;
 CNetObj_PlayerInput m_PhantomInput;
 int m_PhantomPlayIndex;
 int m_RageHookTicks;
+int m_RageMoveDir;
 static const int RAGE_HOOK_HOLD_MIN = 6;
 
 void GetPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -75,6 +75,7 @@ static constexpr int RAGE_PREDICT_STEPS = 25;
 static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
 static constexpr float RAGE_NEAR_MARGIN = 6.f;
 static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
+static constexpr int RAGE_RELEASE_SAFE = 6;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -67,7 +67,9 @@ CNetObj_PlayerInput m_PhantomInput;
 int m_PhantomPlayIndex;
 int m_RageHookTicks;
 int m_RageMoveDir;
+int m_RageMoveTicks;
 static const int RAGE_HOOK_HOLD_MIN = 6;
+static const int RAGE_MOVE_EXTRA = 4;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -72,6 +72,7 @@ static const int RAGE_HOOK_HOLD_MIN = 6;
 static const int RAGE_HOOK_HOLD_MAX = 20;
 static const int RAGE_MOVE_EXTRA = 4;
 static const int RAGE_PREDICT_STEPS = 25;
+static const int RAGE_HOOK_DOWN_HOLD = 3;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -73,6 +73,7 @@ static const int RAGE_HOOK_HOLD_MAX = 20;
 static const int RAGE_MOVE_EXTRA = 4;
 static const int RAGE_PREDICT_STEPS = 25;
 static const int RAGE_HOOK_DOWN_HOLD = 3;
+static const float RAGE_NEAR_MARGIN = 4.f;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -73,7 +73,8 @@ static constexpr int RAGE_HOOK_HOLD_MAX = 20;
 static constexpr int RAGE_MOVE_EXTRA = 4;
 static constexpr int RAGE_PREDICT_STEPS = 25;
 static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
-static constexpr float RAGE_NEAR_MARGIN = 4.f;
+static constexpr float RAGE_NEAR_MARGIN = 6.f;
+static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -68,12 +68,12 @@ int m_PhantomPlayIndex;
 int m_RageHookTicks;
 int m_RageMoveDir;
 int m_RageMoveTicks;
-static const int RAGE_HOOK_HOLD_MIN = 6;
-static const int RAGE_HOOK_HOLD_MAX = 20;
-static const int RAGE_MOVE_EXTRA = 4;
-static const int RAGE_PREDICT_STEPS = 25;
-static const int RAGE_HOOK_DOWN_HOLD = 3;
-static const float RAGE_NEAR_MARGIN = 4.f;
+static constexpr int RAGE_HOOK_HOLD_MIN = 6;
+static constexpr int RAGE_HOOK_HOLD_MAX = 20;
+static constexpr int RAGE_MOVE_EXTRA = 4;
+static constexpr int RAGE_PREDICT_STEPS = 25;
+static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
+static constexpr float RAGE_NEAR_MARGIN = 4.f;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -69,6 +69,7 @@ int m_RageHookTicks;
 int m_RageMoveDir;
 int m_RageMoveTicks;
 static const int RAGE_HOOK_HOLD_MIN = 6;
+static const int RAGE_HOOK_HOLD_MAX = 20;
 static const int RAGE_MOVE_EXTRA = 4;
 
 void GetPath(char *pBuf, int Size) const;


### PR DESCRIPTION
## Summary
- improve freeze rage autoprediction by remembering movement direction
- hold direction while hooking to move away from the wall

## Testing
- `python3 scripts/fix_style.py`

------
https://chatgpt.com/codex/tasks/task_e_687f7fdb8a14832c85823d4f3c645d37