### PR TITLE
Improve freeze rage wall prediction

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -507,8 +507,11 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     };
     int BestDir = 0;
     int BestHold = 0;
+    int ScenarioCount = 0;
     for(const vec2 &DirRaw : vDirs)
     {
+        if(ScenarioCount >= RAGE_SCENARIO_COUNT)
+            break;
         vec2 Dir = DirRaw;
         bool Wall = Dir.y == 0.f && Dir.x != 0.f;
         if(Wall)
@@ -542,43 +545,54 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             for(int Move : aMove)
             {
                 float Dist = distance(Pos, Col);
-                int Hold;
+                int HoldBase;
                 if(DirRaw.y > 0.f)
-                    Hold = RAGE_HOOK_DOWN_HOLD;
+                    HoldBase = RAGE_HOOK_DOWN_HOLD;
                 else
-                    Hold = (int)ceilf(Dist / HookSpeed) + 1;
-                if(Hold < RAGE_HOOK_HOLD_MIN)
-                    Hold = RAGE_HOOK_HOLD_MIN;
-                else if(Hold > RAGE_HOOK_HOLD_MAX)
-                    Hold = RAGE_HOOK_HOLD_MAX;
-                int Freeze = PredictFreezeSeq(Dir, Move, Hold);
-                if(Freeze && Freeze <= Hold && Hold > 1)
+                    HoldBase = (int)ceilf(Dist / HookSpeed) + 1;
+                if(HoldBase < RAGE_HOOK_HOLD_MIN)
+                    HoldBase = RAGE_HOOK_HOLD_MIN;
+                else if(HoldBase > RAGE_HOOK_HOLD_MAX)
+                    HoldBase = RAGE_HOOK_HOLD_MAX;
+                for(int Offset : {-2, 0, 2})
                 {
-                    Hold = Freeze - 1;
-                    Freeze = PredictFreezeSeq(Dir, Move, Hold);
-                }
-                if(Freeze && Freeze <= Hold)
-                    continue;
-                if(Freeze && Freeze <= Hold + RAGE_RELEASE_SAFE)
-                    continue;
-                if(!Freeze || Freeze > BestFreeze)
-                {
-                    Best = Base;
-                    Best.m_Hook = 1;
-                    Best.m_TargetX = (int)(Dir.x * AimLen);
-                    Best.m_TargetY = (int)(Dir.y * AimLen);
-                    Best.m_Direction = Move;
-                    BestFreeze = Freeze ? Freeze : Steps;
-                    BestCol = Col;
-                    BestDir = Move;
-                    BestHold = Hold;
-                    if(!Freeze)
+                    if(ScenarioCount >= RAGE_SCENARIO_COUNT)
                         break;
+                    int Hold = clamp(HoldBase + Offset, RAGE_HOOK_HOLD_MIN, RAGE_HOOK_HOLD_MAX);
+                    int Freeze = PredictFreezeSeq(Dir, Move, Hold);
+                    ScenarioCount++;
+                    if(Freeze && Freeze <= Hold && Hold > 1)
+                    {
+                        Hold = Freeze - 1;
+                        Freeze = PredictFreezeSeq(Dir, Move, Hold);
+                    }
+                    if(Freeze && Freeze <= Hold)
+                        continue;
+                    if(Freeze && Freeze <= Hold + RAGE_RELEASE_SAFE)
+                        continue;
+                    if(!Freeze || Freeze > BestFreeze)
+                    {
+                        Best = Base;
+                        Best.m_Hook = 1;
+                        Best.m_TargetX = (int)(Dir.x * AimLen);
+                        Best.m_TargetY = (int)(Dir.y * AimLen);
+                        Best.m_Direction = Move;
+                        BestFreeze = Freeze ? Freeze : Steps;
+                        BestCol = Col;
+                        BestDir = Move;
+                        BestHold = Hold;
+                        if(!Freeze)
+                            break;
+                    }
                 }
+                if(ScenarioCount >= RAGE_SCENARIO_COUNT)
+                    break;
             }
-            if(BestFreeze == Steps)
+            if(BestFreeze == Steps || ScenarioCount >= RAGE_SCENARIO_COUNT)
                 break;
         }
+        if(ScenarioCount >= RAGE_SCENARIO_COUNT)
+            break;
     }
 
     if(BestFreeze > FreezeCurrent)
@@ -594,9 +608,11 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
 
 void CFujixTas::UpdateFreezeInput(CNetObj_PlayerInput *pInput)
 {
-    EmergencyFreezeStop(pInput);
     if(g_Config.m_ClFujixBlockFreezeRage)
+    {
+        EmergencyFreezeStop(pInput);
         BlockFreezeRageInput(pInput);
+    }
     else
         BlockFreezeInput(pInput);
 }

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -12,6 +12,8 @@
 #include <game/client/components/players.h>
 #include <game/client/prediction/entities/character.h>
 #include <base/system.h>
+#include <array>
+#include <vector>
 #include <cstdlib>
 #include <ctime>
 #include <cmath>
@@ -44,6 +46,8 @@ CFujixTas::CFujixTas()
     m_LastHookState = HOOK_RETRACTED;
     m_LastHookedPlayer = -1;
     m_RageHookTicks = 0;
+    m_RageMoveDir = 0;
+    m_RageMoveTicks = 0;
 }
 
 int CFujixTas::Sizeof() const
@@ -272,6 +276,42 @@ void CFujixTas::MaybeFinishRecord()
         FinishRecord();
 }
 
+bool CFujixTas::NearFreeze(vec2 Pos)
+{
+    const float Half = CCharacterCore::PhysicalSize() / 2.f;
+    const float ExtraMargin = 4.0f;
+    for(float x = -Half - ExtraMargin; x <= Half + ExtraMargin; x += 4.0f)
+    {
+        for(float y = -Half - ExtraMargin; y <= Half + ExtraMargin; y += 4.0f)
+        {
+            int Idx = Collision()->GetPureMapIndex(Pos.x + x, Pos.y + y);
+            int Tile = Collision()->GetTileIndex(Idx);
+            int Front = Collision()->GetFrontTileIndex(Idx);
+            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
+                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
+            if(Freeze)
+                return true;
+        }
+    }
+    return false;
+}
+
+void CFujixTas::EmergencyFreezeStop(CNetObj_PlayerInput *pInput)
+{
+    vec2 Vel = GameClient()->m_PredictedChar.m_Vel;
+    vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
+    vec2 NextPos = Pos + Vel * 0.5f;
+    if(NearFreeze(NextPos))
+    {
+        pInput->m_Direction = 0;
+        pInput->m_Jump = 0;
+        if(Vel.y < -5.0f)
+            pInput->m_Hook = 0;
+        if(fabsf(Vel.x) > 0.1f)
+            pInput->m_Direction = Vel.x > 0 ? -1 : 1;
+    }
+}
+
 void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
 {
     if(!g_Config.m_ClFujixBlockFreezeLegit || !GameClient()->m_Snap.m_pLocalCharacter)
@@ -280,7 +320,7 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input, int HookMode) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
-        const int Steps = 12;
+        const int Steps = RAGE_PREDICT_STEPS;
         for(int i = 0; i < Steps; i++)
         {
             CNetObj_PlayerInput Step = Input;
@@ -294,12 +334,7 @@ void CFujixTas::BlockFreezeInput(CNetObj_PlayerInput *pInput)
             Core.Tick(true);
             Core.Move();
             Core.Quantize();
-            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
-            int Tile = Collision()->GetTileIndex(Index);
-            int Front = Collision()->GetFrontTileIndex(Index);
-            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
-                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
-            if(Freeze)
+            if(NearFreeze(Core.m_Pos))
                 return i + 1;
         }
         return 0;
@@ -369,13 +404,24 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     if(m_RageHookTicks > 0)
     {
         pInput->m_Hook = 1;
+        pInput->m_Direction = m_RageMoveDir;
         m_RageHookTicks--;
         if(GameClient()->m_PredictedChar.m_HookState != HOOK_FLYING)
             m_RageHookTicks = 0;
+        if(m_RageHookTicks == 0 && m_RageMoveTicks == 0)
+            m_RageMoveDir = 0;
         return;
     }
 
-    const int Steps = 24;
+    if(m_RageMoveTicks > 0)
+    {
+        pInput->m_Direction = m_RageMoveDir;
+        m_RageMoveTicks--;
+        if(m_RageMoveTicks == 0)
+            m_RageMoveDir = 0;
+    }
+
+    const int Steps = RAGE_PREDICT_STEPS;
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
@@ -385,12 +431,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
             Core.Tick(true);
             Core.Move();
             Core.Quantize();
-            int Index = Collision()->GetPureMapIndex(Core.m_Pos.x, Core.m_Pos.y);
-            int Tile = Collision()->GetTileIndex(Index);
-            int Front = Collision()->GetFrontTileIndex(Index);
-            bool Freeze = Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE ||
-                          Front == TILE_FREEZE || Front == TILE_DFREEZE || Front == TILE_LFREEZE;
-            if(Freeze)
+            if(NearFreeze(Core.m_Pos))
                 return i + 1;
         }
         return 0;
@@ -399,23 +440,74 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     CNetObj_PlayerInput Base = *pInput;
     int FreezeCurrent = PredictFreeze(Base);
     if(!FreezeCurrent)
+    {
+        m_RageMoveDir = 0;
+        m_RageMoveTicks = 0;
         return;
+    }
 
     CNetObj_PlayerInput Best = Base;
     int BestFreeze = FreezeCurrent;
     vec2 BestCol = vec2(0.f, 0.f);
-    bool BestWall = false;
 
     if(pInput->m_Hook)
-        return;
+    {
+        int Freeze = PredictFreeze(Base);
+        if(!Freeze)
+        {
+            m_RageMoveDir = 0;
+            m_RageMoveTicks = 0;
+            return;
+        }
+    }
 
-    static const vec2 s_aDirs[] = {
-        vec2(0.f, -1.f), vec2(1.f, -1.f), vec2(-1.f, -1.f), vec2(1.f, 0.f),
-        vec2(-1.f, 0.f)};
+    std::vector<vec2> vDirs;
+    vDirs.reserve(RAGE_DIR_TOTAL + 6);
+    for(int i = 0; i < RAGE_DIR_TOTAL; i++)
+    {
+        float a = 2.f * pi * i / RAGE_DIR_TOTAL;
+        vDirs.push_back(vec2(cosf(a), sinf(a)));
+    }
+    int WantedDir = clamp(Base.m_Direction, -1, 1);
+    if(WantedDir)
+    {
+        vDirs.push_back(normalize(vec2(WantedDir * 0.25f, -1.f)));
+        vDirs.push_back(normalize(vec2(WantedDir * 0.5f, -1.f)));
+        vDirs.push_back(normalize(vec2(WantedDir * 0.75f, -1.f)));
+    }
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
     const float AimLen = HookLen;
-    for(const vec2 &DirRaw : s_aDirs)
+    float HookSpeed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
+
+    auto PredictFreezeSeq = [&](const vec2 &Dir, int Move, int Hold) {
+        CCharacterCore Core = GameClient()->m_PredictedChar;
+        Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
+        int StepLimit = Hold + RAGE_EXTRA_AFTER_HOLD + RAGE_RELEASE_SAFE;
+        if(StepLimit < Steps)
+            StepLimit = Steps;
+        for(int i = 0; i < StepLimit; i++)
+        {
+            CNetObj_PlayerInput Step = Base;
+            Step.m_Direction = Move;
+            if(i == 0)
+            {
+                Step.m_TargetX = (int)(Dir.x * AimLen);
+                Step.m_TargetY = (int)(Dir.y * AimLen);
+            }
+            Step.m_Hook = i < Hold ? 1 : 0;
+            Core.m_Input = Step;
+            Core.Tick(true);
+            Core.Move();
+            Core.Quantize();
+            if(NearFreeze(Core.m_Pos))
+                return i + 1;
+        }
+        return 0;
+    };
+    int BestDir = 0;
+    int BestHold = 0;
+    for(const vec2 &DirRaw : vDirs)
     {
         vec2 Dir = DirRaw;
         bool Wall = Dir.y == 0.f && Dir.x != 0.f;
@@ -426,44 +518,83 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         vec2 To = Pos + Dir * HookLen;
         vec2 Col;
         int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
-        if(Hit && Hit != TILE_NOHOOK)
+        int ColIndex = Collision()->GetPureMapIndex(Col.x, Col.y);
+        int ColTile = Collision()->GetTileIndex(ColIndex);
+        int ColFront = Collision()->GetFrontTileIndex(ColIndex);
+        bool ColFreeze = ColTile == TILE_FREEZE || ColTile == TILE_DFREEZE ||
+                         ColTile == TILE_LFREEZE || ColFront == TILE_FREEZE ||
+                         ColFront == TILE_DFREEZE || ColFront == TILE_LFREEZE;
+        if(Hit && Hit != TILE_NOHOOK && !ColFreeze)
         {
-            CNetObj_PlayerInput Test = Base;
-            Test.m_Hook = 1;
-            Test.m_TargetX = (int)(Dir.x * AimLen);
-            Test.m_TargetY = (int)(Dir.y * AimLen);
-            int Freeze = PredictFreeze(Test);
-            if(!Freeze || Freeze > BestFreeze)
+            int aMove[3];
+            if(WantedDir)
             {
-                Best = Test;
-                BestFreeze = Freeze ? Freeze : Steps;
-                BestCol = Col;
-                BestWall = Wall;
-                if(!Freeze)
-                    break;
+                aMove[0] = WantedDir;
+                aMove[1] = 0;
+                aMove[2] = -WantedDir;
             }
+            else
+            {
+                aMove[0] = 0;
+                aMove[1] = 1;
+                aMove[2] = -1;
+            }
+            for(int Move : aMove)
+            {
+                float Dist = distance(Pos, Col);
+                int Hold;
+                if(DirRaw.y > 0.f)
+                    Hold = RAGE_HOOK_DOWN_HOLD;
+                else
+                    Hold = (int)ceilf(Dist / HookSpeed) + 1;
+                if(Hold < RAGE_HOOK_HOLD_MIN)
+                    Hold = RAGE_HOOK_HOLD_MIN;
+                else if(Hold > RAGE_HOOK_HOLD_MAX)
+                    Hold = RAGE_HOOK_HOLD_MAX;
+                int Freeze = PredictFreezeSeq(Dir, Move, Hold);
+                if(Freeze && Freeze <= Hold && Hold > 1)
+                {
+                    Hold = Freeze - 1;
+                    Freeze = PredictFreezeSeq(Dir, Move, Hold);
+                }
+                if(Freeze && Freeze <= Hold)
+                    continue;
+                if(Freeze && Freeze <= Hold + RAGE_RELEASE_SAFE)
+                    continue;
+                if(!Freeze || Freeze > BestFreeze)
+                {
+                    Best = Base;
+                    Best.m_Hook = 1;
+                    Best.m_TargetX = (int)(Dir.x * AimLen);
+                    Best.m_TargetY = (int)(Dir.y * AimLen);
+                    Best.m_Direction = Move;
+                    BestFreeze = Freeze ? Freeze : Steps;
+                    BestCol = Col;
+                    BestDir = Move;
+                    BestHold = Hold;
+                    if(!Freeze)
+                        break;
+                }
+            }
+            if(BestFreeze == Steps)
+                break;
         }
     }
 
     if(BestFreeze > FreezeCurrent)
     {
         *pInput = Best;
-        if(BestWall)
-        {
-            vec2 Pos = GameClient()->m_PredictedChar.m_Pos;
-            pInput->m_Direction = Pos.x < BestCol.x ? -1 : 1; // move away from the wall
-        }
-        float Speed = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookFireSpeed;
-        float Dist = distance(GameClient()->m_PredictedChar.m_Pos, BestCol);
-        int Hold = (int)ceilf(Dist / Speed) + 1;
-        if(Hold < RAGE_HOOK_HOLD_MIN)
-            Hold = RAGE_HOOK_HOLD_MIN;
-        m_RageHookTicks = Hold;
+        m_RageMoveDir = BestDir;
+        pInput->m_Direction = BestDir;
+
+        m_RageHookTicks = BestHold;
+        m_RageMoveTicks = BestHold + RAGE_MOVE_EXTRA;
     }
 }
 
 void CFujixTas::UpdateFreezeInput(CNetObj_PlayerInput *pInput)
 {
+    EmergencyFreezeStop(pInput);
     if(g_Config.m_ClFujixBlockFreezeRage)
         BlockFreezeRageInput(pInput);
     else

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -48,6 +48,7 @@ CFujixTas::CFujixTas()
     m_RageHookTicks = 0;
     m_RageMoveDir = 0;
     m_RageMoveTicks = 0;
+    m_LastWantedDir = 0;
 }
 
 int CFujixTas::Sizeof() const
@@ -438,11 +439,17 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     };
 
     CNetObj_PlayerInput Base = *pInput;
+    if(Base.m_Direction)
+        m_LastWantedDir = clamp(Base.m_Direction, -1, 1);
     int FreezeCurrent = PredictFreeze(Base);
     if(!FreezeCurrent)
     {
         m_RageMoveDir = 0;
         m_RageMoveTicks = 0;
+        if(Base.m_Direction)
+            m_LastWantedDir = clamp(Base.m_Direction, -1, 1);
+        else
+            m_LastWantedDir = 0;
         return;
     }
 
@@ -457,6 +464,10 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         {
             m_RageMoveDir = 0;
             m_RageMoveTicks = 0;
+            if(Base.m_Direction)
+                m_LastWantedDir = clamp(Base.m_Direction, -1, 1);
+            else
+                m_LastWantedDir = 0;
             return;
         }
     }
@@ -468,7 +479,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         float a = 2.f * pi * i / RAGE_DIR_TOTAL;
         vDirs.push_back(vec2(cosf(a), sinf(a)));
     }
-    int WantedDir = clamp(Base.m_Direction, -1, 1);
+    int WantedDir = m_LastWantedDir;
     if(WantedDir)
     {
         for(float f = 0.2f; f <= 1.0f; f += 0.2f)
@@ -520,13 +531,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         vec2 To = Pos + Dir * HookLen;
         vec2 Col;
         int Hit = Collision()->IntersectLineTeleHook(Pos, To, &Col, nullptr);
-        int ColIndex = Collision()->GetPureMapIndex(Col.x, Col.y);
-        int ColTile = Collision()->GetTileIndex(ColIndex);
-        int ColFront = Collision()->GetFrontTileIndex(ColIndex);
-        bool ColFreeze = ColTile == TILE_FREEZE || ColTile == TILE_DFREEZE ||
-                         ColTile == TILE_LFREEZE || ColFront == TILE_FREEZE ||
-                         ColFront == TILE_DFREEZE || ColFront == TILE_LFREEZE;
-        if(Hit && Hit != TILE_NOHOOK && !ColFreeze)
+        if(Hit && Hit != TILE_NOHOOK)
         {
             int aMove[3];
             if(WantedDir)

--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -279,7 +279,7 @@ void CFujixTas::MaybeFinishRecord()
 bool CFujixTas::NearFreeze(vec2 Pos)
 {
     const float Half = CCharacterCore::PhysicalSize() / 2.f;
-    const float ExtraMargin = 4.0f;
+    const float ExtraMargin = RAGE_NEAR_MARGIN;
     for(float x = -Half - ExtraMargin; x <= Half + ExtraMargin; x += 4.0f)
     {
         for(float y = -Half - ExtraMargin; y <= Half + ExtraMargin; y += 4.0f)
@@ -471,9 +471,8 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
     int WantedDir = clamp(Base.m_Direction, -1, 1);
     if(WantedDir)
     {
-        vDirs.push_back(normalize(vec2(WantedDir * 0.25f, -1.f)));
-        vDirs.push_back(normalize(vec2(WantedDir * 0.5f, -1.f)));
-        vDirs.push_back(normalize(vec2(WantedDir * 0.75f, -1.f)));
+        for(float f = 0.2f; f <= 1.0f; f += 0.2f)
+            vDirs.push_back(normalize(vec2(WantedDir * f, -1.f)));
     }
 
     const float HookLen = GameClient()->GetTuning(g_Config.m_ClDummy)->m_HookLength;
@@ -554,7 +553,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
                     HoldBase = RAGE_HOOK_HOLD_MIN;
                 else if(HoldBase > RAGE_HOOK_HOLD_MAX)
                     HoldBase = RAGE_HOOK_HOLD_MAX;
-                for(int Offset : {-2, 0, 2})
+                for(int Offset : {-3, -1, 0, 1, 3})
                 {
                     if(ScenarioCount >= RAGE_SCENARIO_COUNT)
                         break;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -71,13 +71,13 @@ int m_RageMoveTicks;
 static constexpr int RAGE_HOOK_HOLD_MIN = 6;
 static constexpr int RAGE_HOOK_HOLD_MAX = 20;
 static constexpr int RAGE_MOVE_EXTRA = 4;
-static constexpr int RAGE_PREDICT_STEPS = 24;
+static constexpr int RAGE_PREDICT_STEPS = 30;
 static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
-static constexpr float RAGE_NEAR_MARGIN = 2.f;
+static constexpr float RAGE_NEAR_MARGIN = 3.f;
 static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
 static constexpr int RAGE_RELEASE_SAFE = 6;
-static constexpr int RAGE_DIR_TOTAL = 24;
-static constexpr int RAGE_SCENARIO_COUNT = 20;
+static constexpr int RAGE_DIR_TOTAL = 32;
+static constexpr int RAGE_SCENARIO_COUNT = 100;
 
 bool NearFreeze(vec2 Pos);
 void EmergencyFreezeStop(CNetObj_PlayerInput *pInput);

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -66,7 +66,20 @@ int m_PhantomStep;
 CNetObj_PlayerInput m_PhantomInput;
 int m_PhantomPlayIndex;
 int m_RageHookTicks;
-static const int RAGE_HOOK_HOLD_MIN = 6;
+int m_RageMoveDir;
+int m_RageMoveTicks;
+static constexpr int RAGE_HOOK_HOLD_MIN = 6;
+static constexpr int RAGE_HOOK_HOLD_MAX = 20;
+static constexpr int RAGE_MOVE_EXTRA = 4;
+static constexpr int RAGE_PREDICT_STEPS = 24;
+static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
+static constexpr float RAGE_NEAR_MARGIN = 2.f;
+static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
+static constexpr int RAGE_RELEASE_SAFE = 6;
+static constexpr int RAGE_DIR_TOTAL = 24;
+
+bool NearFreeze(vec2 Pos);
+void EmergencyFreezeStop(CNetObj_PlayerInput *pInput);
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -68,6 +68,7 @@ int m_PhantomPlayIndex;
 int m_RageHookTicks;
 int m_RageMoveDir;
 int m_RageMoveTicks;
+int m_LastWantedDir;
 static constexpr int RAGE_HOOK_HOLD_MIN = 6;
 static constexpr int RAGE_HOOK_HOLD_MAX = 20;
 static constexpr int RAGE_MOVE_EXTRA = 4;

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -77,6 +77,7 @@ static constexpr float RAGE_NEAR_MARGIN = 2.f;
 static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
 static constexpr int RAGE_RELEASE_SAFE = 6;
 static constexpr int RAGE_DIR_TOTAL = 24;
+static constexpr int RAGE_SCENARIO_COUNT = 20;
 
 bool NearFreeze(vec2 Pos);
 void EmergencyFreezeStop(CNetObj_PlayerInput *pInput);


### PR DESCRIPTION
## Summary
- evaluate horizontal directions during hook selection
- hold lateral input for a short period after hooking
- keep hook and movement prediction active while freeze persists
- clamp hook hold time and consider player direction when picking target
- refine hook prediction with more directions and dynamic hold clamp
- better freeze rage simulation when releasing the hook
- block unsafe user hooks and check freeze at hook point
- support short downward hooks to reduce vertical speed
- check tiles around the player for freeze to keep distance from ceilings and walls
- fix constexpr usage for rage constants
- extend rage freeze prediction with a post-hook buffer
- skip hook options that would freeze shortly after releasing the hook
- expand rage prediction window and search grid every tick
- enlarge the near-freeze check area and add emergency stop logic

## Testing
- `python3 scripts/fix_style.py --dry-run` *(fails: `Found no clang-format 10`)*
- `python3 scripts/fix_style.py` *(fails: `Found no clang-format 10`)*

------
https://chatgpt.com/codex/tasks/task_e_687f7fdb8a14832c85823d4f3c645d37