### PR TITLE
Improve freeze rage mode

### DIFF
--- a/src/game/client/components/fujix_tas.cpp
+++ b/src/game/client/components/fujix_tas.cpp
@@ -424,6 +424,18 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         }
         return false;
     };
+    auto PathNearFreeze = [&](vec2 From, vec2 To) {
+        float Dist = distance(From, To);
+        int StepsLine = maximum(1, (int)(Dist / RAGE_PATH_STEP));
+        for(int i = 0; i <= StepsLine; i++)
+        {
+            float a = i / (float)StepsLine;
+            vec2 Pos = mix(From, To, a);
+            if(NearFreeze(Pos))
+                return true;
+        }
+        return false;
+    };
     auto PredictFreeze = [&](const CNetObj_PlayerInput &Input) {
         CCharacterCore Core = GameClient()->m_PredictedChar;
         Core.SetCoreWorld(&GameClient()->m_PredictedWorld.m_Core, Collision(), GameClient()->m_PredictedWorld.Teams());
@@ -526,7 +538,7 @@ void CFujixTas::BlockFreezeRageInput(CNetObj_PlayerInput *pInput)
         bool ColFreeze = ColTile == TILE_FREEZE || ColTile == TILE_DFREEZE ||
                          ColTile == TILE_LFREEZE || ColFront == TILE_FREEZE ||
                          ColFront == TILE_DFREEZE || ColFront == TILE_LFREEZE;
-        if(Hit && Hit != TILE_NOHOOK && !ColFreeze)
+        if(Hit && Hit != TILE_NOHOOK && !ColFreeze && !PathNearFreeze(Pos, Col))
         {
             int aMove[3];
             if(WantedDir)

--- a/src/game/client/components/fujix_tas.h
+++ b/src/game/client/components/fujix_tas.h
@@ -71,12 +71,13 @@ int m_RageMoveTicks;
 static constexpr int RAGE_HOOK_HOLD_MIN = 6;
 static constexpr int RAGE_HOOK_HOLD_MAX = 20;
 static constexpr int RAGE_MOVE_EXTRA = 4;
-static constexpr int RAGE_PREDICT_STEPS = 30;
+static constexpr int RAGE_PREDICT_STEPS = 50;
 static constexpr int RAGE_HOOK_DOWN_HOLD = 3;
 static constexpr float RAGE_NEAR_MARGIN = 6.f;
 static constexpr int RAGE_EXTRA_AFTER_HOLD = 10;
 static constexpr int RAGE_RELEASE_SAFE = 6;
 static constexpr int RAGE_DIR_TOTAL = 24;
+static constexpr float RAGE_PATH_STEP = 4.f;
 
 void GetPath(char *pBuf, int Size) const;
 void GetHookPath(char *pBuf, int Size) const;


### PR DESCRIPTION
## Summary
- extend prediction window in rage mode
- add path-based freeze detection to rage mode

## Testing
- `cmake -Bbuild -GNinja`
- `cmake --build build --target run_tests` *(fails: unknown target)*

------
https://chatgpt.com/codex/tasks/task_e_688111ab6080832c96f0f40726e9513a